### PR TITLE
Sagas - no text replacement yet

### DIFF
--- a/Assets/Editor/CardTypeEditor.cs
+++ b/Assets/Editor/CardTypeEditor.cs
@@ -2,11 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.Rendering.Universal.ShaderGraph;
+using System;
+using System.Drawing.Printing;
 
 [CustomEditor(typeof(CardType))]
 public class CardTypeEditor : Editor {
 
     EffectStepName stepName = EffectStepName.Default;
+    int editedEffectWorkflow = 0;
     public override void OnInspectorGUI() {
         CardType cardType = (CardType) target;
         DrawDefaultInspector();
@@ -18,11 +22,31 @@ public class CardTypeEditor : Editor {
         stepName = (EffectStepName) EditorGUILayout.EnumPopup(
             "New effect",
             stepName);
+        editedEffectWorkflow = EditorGUILayout.IntField(editedEffectWorkflow);
 
         if (GUILayout.Button("Add Effect")) {
             EffectStep newEffect = InstantiateFromClassname.Instantiate<EffectStep>(
                 stepName.ToString(), 
                 new object[] {});
+            
+            EffectWorkflow retrievedWorkflow = null;
+            if (cardType.effectWorkflows.Count == 0) {
+                cardType.effectWorkflows.Add(new EffectWorkflow());
+            }
+            if(cardType.effectWorkflows.Count < editedEffectWorkflow) {
+                Debug.LogError("Attempting to edit an effect workflow that does not exist. Please check " +
+                "the amount of effect workflows you have in the list, and the zero-indexed value you have in " +
+                "editedEffectWorkflow");
+            } else {
+                Debug.Log("effectWorkflows null: " + cardType.effectWorkflows == null ? " yes " : " no ");
+                Debug.Log("effectWorkflows count: " + cardType.effectWorkflows.Count);
+                retrievedWorkflow = cardType.effectWorkflows[editedEffectWorkflow];
+                Debug.Log("retrievedWorkflow null: " + retrievedWorkflow == null ? " yes " : " no ");
+            }
+            
+            if(retrievedWorkflow == null) {
+                Debug.LogError("Error while attempting to retrieve the workflow to add a new effect to");
+            }
 
             if(newEffect == null) {
                 Debug.LogError("Failed to instantiate effect step, " +
@@ -31,9 +55,30 @@ public class CardTypeEditor : Editor {
                 " the arguments in the constructor");
             }
             else {
-                cardType.effectSteps.Add(newEffect);
+                retrievedWorkflow.effectSteps.Add(newEffect);
             }
+            save(cardType);
+
         }
+
+        if (GUILayout.Button("Add EffectWorkflow")) {
+            cardType.effectWorkflows.Add(new EffectWorkflow());
+            save(cardType);
+        }
+
+        if (GUILayout.Button("Migrate EffectSteps")) {
+            cardType.effectWorkflows.Insert(0, new EffectWorkflow(cardType.effectSteps));
+            save(cardType);
+        }
+    }
+
+    private void save(CardType cardType) {
+        // These three calls cause the asset to actually be modified
+        // on disc when we hit the button
+        AssetDatabase.Refresh();
+        EditorUtility.SetDirty(cardType);
+        AssetDatabase.SaveAssets();
+
     }
 
 }

--- a/Assets/Editor/CardTypeEditor.cs
+++ b/Assets/Editor/CardTypeEditor.cs
@@ -38,10 +38,7 @@ public class CardTypeEditor : Editor {
                 "the amount of effect workflows you have in the list, and the zero-indexed value you have in " +
                 "editedEffectWorkflow");
             } else {
-                Debug.Log("effectWorkflows null: " + cardType.effectWorkflows == null ? " yes " : " no ");
-                Debug.Log("effectWorkflows count: " + cardType.effectWorkflows.Count);
                 retrievedWorkflow = cardType.effectWorkflows[editedEffectWorkflow];
-                Debug.Log("retrievedWorkflow null: " + retrievedWorkflow == null ? " yes " : " no ");
             }
             
             if(retrievedWorkflow == null) {
@@ -66,10 +63,6 @@ public class CardTypeEditor : Editor {
             save(cardType);
         }
 
-        if (GUILayout.Button("Migrate EffectSteps")) {
-            cardType.effectWorkflows.Insert(0, new EffectWorkflow(cardType.effectSteps));
-            save(cardType);
-        }
     }
 
     private void save(CardType cardType) {

--- a/Assets/Scenes/Map/GenerateMap.unity
+++ b/Assets/Scenes/Map/GenerateMap.unity
@@ -208,7 +208,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 131.05
+  m_fontSize: 53.05
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -548,7 +548,7 @@ MonoBehaviour:
   startingActiveCompanions:
   - {fileID: 11400000, guid: bb8900a5e0f2ab34a8c486d19dcef389, type: 2}
   - {fileID: 11400000, guid: a388cdca9749764489c477a814a4dd5b, type: 2}
-  - {fileID: 11400000, guid: f64c62bd77fcea846a5c19bed998aeb6, type: 2}
+  - {fileID: 11400000, guid: dd43e974983001345a0bc96e36057440, type: 2}
   startingBenchCompanions: []
 --- !u!114 &663117524
 MonoBehaviour:
@@ -721,7 +721,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 82.45
+  m_fontSize: 33.35
   m_fontSizeBase: 136.42
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Defend.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Defend.asset
@@ -22,9 +22,18 @@ MonoBehaviour:
   - rid: 9024302470308298760
   - rid: 8939928337977442491
   - rid: 9024302470308298761
+  effectWorkflows:
+  - rid: 2116895648763871354
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871354
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298760
+        - rid: 8939928337977442491
+        - rid: 9024302470308298761
     - rid: 8939928337977442491
       type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Defend.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Defend.asset
@@ -18,10 +18,6 @@ MonoBehaviour:
   Artwork: {fileID: 21300000, guid: ac2f6571b8a37954abd0657d090050d5, type: 3}
   vfxPrefab: {fileID: 0}
   playable: 1
-  effectSteps:
-  - rid: 9024302470308298760
-  - rid: 8939928337977442491
-  - rid: 9024302470308298761
   effectWorkflows:
   - rid: 2116895648763871354
   references:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Strike.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BasicCards/Strike.asset
@@ -22,9 +22,18 @@ MonoBehaviour:
   - rid: 9024302470308298763
   - rid: 8939928337977442304
   - rid: 9024302470308298764
+  effectWorkflows:
+  - rid: 2116895648763871355
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871355
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298763
+        - rid: 8939928337977442304
+        - rid: 9024302470308298764
     - rid: 8939928337977442304
       type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Blood Letting.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Blood Letting.asset
@@ -22,9 +22,18 @@ MonoBehaviour:
   - rid: 9024302470308298767
   - rid: 9024302470308298769
   - rid: 9024302470308298770
+  effectWorkflows:
+  - rid: 2116895648763871349
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871349
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298767
+        - rid: 9024302470308298769
+        - rid: 9024302470308298770
     - rid: 9024302470308298767
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Blood Sacrifice.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Blood Sacrifice.asset
@@ -23,9 +23,19 @@ MonoBehaviour:
   - rid: 9024302470308298774
   - rid: 9024302470308298772
   - rid: 9024302470308298773
+  effectWorkflows:
+  - rid: 2116895648763871350
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871350
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298771
+        - rid: 9024302470308298774
+        - rid: 9024302470308298772
+        - rid: 9024302470308298773
     - rid: 9024302470308298771
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Double Strike.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Double Strike.asset
@@ -22,9 +22,18 @@ MonoBehaviour:
   - rid: 9024302470308298775
   - rid: 9024302470308298776
   - rid: 9024302470308298777
+  effectWorkflows:
+  - rid: 2116895648763871351
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871351
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298775
+        - rid: 9024302470308298776
+        - rid: 9024302470308298777
     - rid: 9024302470308298775
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Final Form.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Final Form.asset
@@ -23,9 +23,18 @@ MonoBehaviour:
   - rid: 9024302470308298778
   - rid: 9024302470308298779
   - rid: 9024302470308298780
+  effectWorkflows:
+  - rid: 2116895648763871352
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871352
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298778
+        - rid: 9024302470308298779
+        - rid: 9024302470308298780
     - rid: 9024302470308298778
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Vengeful Sweep.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/BeezelBumbler/Vengeful Sweep.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298781
   - rid: 9024302470308298782
+  effectWorkflows:
+  - rid: 2116895648763871353
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871353
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298781
+        - rid: 9024302470308298782
     - rid: 9024302470308298781
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/BodySlam.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/BodySlam.asset
@@ -23,9 +23,19 @@ MonoBehaviour:
   - rid: 9024302470308298786
   - rid: 9024302470308298784
   - rid: 9024302470308298785
+  effectWorkflows:
+  - rid: 2116895648763871342
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871342
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298783
+        - rid: 9024302470308298786
+        - rid: 9024302470308298784
+        - rid: 9024302470308298785
     - rid: 9024302470308298783
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Death's Bounty.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Death's Bounty.asset
@@ -22,9 +22,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298787
   - rid: 9024302470308298788
+  effectWorkflows:
+  - rid: 2116895648763871343
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871343
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298787
+        - rid: 9024302470308298788
     - rid: 9024302470308298787
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Fat Reserves.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Fat Reserves.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298789
   - rid: 9024302470308298790
+  effectWorkflows:
+  - rid: 2116895648763871344
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871344
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298789
+        - rid: 9024302470308298790
     - rid: 9024302470308298789
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/FatCells.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/FatCells.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298791
   - rid: 9024302470308298792
+  effectWorkflows:
+  - rid: 2116895648763871345
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871345
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298791
+        - rid: 9024302470308298792
     - rid: 9024302470308298791
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Iron Skin.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Iron Skin.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298793
   - rid: 9024302470308298794
+  effectWorkflows:
+  - rid: 2116895648763871346
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871346
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298793
+        - rid: 9024302470308298794
     - rid: 9024302470308298793
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Sheltering Presence.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Sheltering Presence.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302470308298795
   - rid: 9024302470308298796
+  effectWorkflows:
+  - rid: 2116895648763871347
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871347
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298795
+        - rid: 9024302470308298796
     - rid: 9024302470308298795
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Taunt.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Endurance/Taunt.asset
@@ -22,9 +22,18 @@ MonoBehaviour:
   - rid: 9024302837437038646
   - rid: 9024302837437038670
   - rid: 9024302837437038671
+  effectWorkflows:
+  - rid: 2116895648763871348
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871348
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302837437038646
+        - rid: 9024302837437038670
+        - rid: 9024302837437038671
     - rid: 9024302837437038646
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Bellows.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Bellows.asset
@@ -23,9 +23,19 @@ MonoBehaviour:
   - rid: 9024302470308298797
   - rid: 9024302470308298800
   - rid: 9024302470308298799
+  effectWorkflows:
+  - rid: 2116895648763871336
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871336
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302470308298798
+        - rid: 9024302470308298797
+        - rid: 9024302470308298800
+        - rid: 9024302470308298799
     - rid: 9024302470308298797
       type: {class: DrawCards, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Burn.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Burn.asset
@@ -16,8 +16,15 @@ MonoBehaviour:
   Description: Ouch. Takes up space in the deck.
   Cost: 0
   Artwork: {fileID: 21300000, guid: 8d4e86e0a7911224ea47d026355ef835, type: 3}
+  vfxPrefab: {fileID: 0}
   playable: 0
-  EffectProcedures: []
+  effectSteps: []
+  effectWorkflows:
+  - rid: 2116895648763871337
   references:
     version: 2
-    RefIds: []
+    RefIds:
+    - rid: 2116895648763871337
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps: []

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/PurifyingInferno.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/PurifyingInferno.asset
@@ -25,9 +25,20 @@ MonoBehaviour:
   - rid: 9024302837437038722
   - rid: 9024302837437038723
   - rid: 9024302837437038724
+  effectWorkflows:
+  - rid: 2116895648763871338
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871338
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302837437038720
+        - rid: 9024302837437038721
+        - rid: 9024302837437038722
+        - rid: 9024302837437038723
+        - rid: 9024302837437038724
     - rid: 9024302837437038720
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Self-Sharpening Blade.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Self-Sharpening Blade.asset
@@ -19,6 +19,12 @@ MonoBehaviour:
   vfxPrefab: {fileID: 0}
   playable: 1
   effectSteps: []
+  effectWorkflows:
+  - rid: 2116895648763871339
   references:
     version: 2
-    RefIds: []
+    RefIds:
+    - rid: 2116895648763871339
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps: []

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Sooty Armor.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Sooty Armor.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
   - rid: 1886371092460208244
   - rid: 1886371092460208245
   - rid: 1886371092460208246
+  effectWorkflows:
+  - rid: 2116895648763871340
   references:
     version: 2
     RefIds:
@@ -57,3 +59,10 @@ MonoBehaviour:
         scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871340
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208244
+        - rid: 1886371092460208245
+        - rid: 1886371092460208246

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Trial By Fire.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Incinerator/Trial By Fire.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
   - rid: 1886371092460208247
   - rid: 1886371092460208248
   - rid: 1886371092460208249
+  effectWorkflows:
+  - rid: 2116895648763871341
   references:
     version: 2
     RefIds:
@@ -57,3 +59,10 @@ MonoBehaviour:
         scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871341
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208247
+        - rid: 1886371092460208248
+        - rid: 1886371092460208249

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Brainstorm.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Brainstorm.asset
@@ -24,6 +24,8 @@ MonoBehaviour:
   - rid: 1886371092460208277
   - rid: 1886371092460208255
   - rid: 1886371092460208256
+  effectWorkflows:
+  - rid: 2116895648763871330
   references:
     version: 2
     RefIds:
@@ -73,3 +75,12 @@ MonoBehaviour:
         inputKey: cardsInHand
         typesToCount: 01000000
         outputKey: numberOfCardsInHand
+    - rid: 2116895648763871330
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208250
+        - rid: 1886371092460208252
+        - rid: 1886371092460208277
+        - rid: 1886371092460208255
+        - rid: 1886371092460208256

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Con Artist.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Con Artist.asset
@@ -1,0 +1,162 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: Con Artist
+  m_EditorClassIdentifier: 
+  Name: Con Artist (saga)
+  Description: Changes on cast (Don't have text replacement yet)
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: cea2c9bf87b0c4dfdafb697a3ff00959, type: 3}
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  effectWorkflows:
+  - rid: 2116895648763871334
+  - rid: 2116895650466496513
+  - rid: 2116895650466496521
+  references:
+    version: 2
+    RefIds:
+    - rid: 2116895648763871334
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 2116895650466496512
+        - rid: 2116895650466496519
+    - rid: 2116895650466496512
+      type: {class: ManaChange, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: ManaChange
+        scale: 2
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 2116895650466496513
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 2116895650466496515
+        - rid: 2116895650466496514
+        - rid: 2116895650466496516
+        - rid: 2116895650466496517
+        - rid: 2116895650466496520
+    - rid: 2116895650466496514
+      type: {class: DrawCards, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DrawCards
+        inputKey: draw_target
+        outputKey: 
+        scale: 3
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 2116895650466496515
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: draw_target
+        validTargets: 
+        number: 1
+        specialTargetRule: 4
+        cantCancelTargetting: 0
+    - rid: 2116895650466496516
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: discard_target
+        validTargets: 03000000
+        number: 3
+        specialTargetRule: 5
+        cantCancelTargetting: 1
+    - rid: 2116895650466496517
+      type: {class: CardInHandEffect, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CardInHandEffect
+        inputKey: discard_target
+        effect: 0
+    - rid: 2116895650466496519
+      type: {class: SetCardEffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: SetCardEffectWorkflow
+        cardInputKey: 
+        chapterInputKey: 
+        increment: 1
+        modifyThisCard: 1
+    - rid: 2116895650466496520
+      type: {class: SetCardEffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: SetCardEffectWorkflow
+        cardInputKey: 
+        chapterInputKey: 
+        increment: 1
+        modifyThisCard: 1
+    - rid: 2116895650466496521
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 2116895650466496522
+        - rid: 2116895650466496524
+        - rid: 2116895650466496526
+        - rid: 2116895650466496527
+        - rid: 2116895650466496528
+        - rid: 2116895650466496529
+    - rid: 2116895650466496522
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 02000000
+        number: 1
+        specialTargetRule: 0
+        cantCancelTargetting: 0
+    - rid: 2116895650466496524
+      type: {class: GetNumberOfCardsInHand, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetNumberOfCardsInHand
+        outputKey: cardsInHand
+    - rid: 2116895650466496526
+      type: {class: GetCastCountFromCard, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetCastCountFromCard
+        inputKey: 
+        outputKey: castCount
+        countFromThisCard: 1
+    - rid: 2116895650466496527
+      type: {class: MathStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: MathStep
+        inputKey: castCount
+        operand2InputKey: 
+        operation: 0
+        scale: 1
+        outputKey: castCountPlusOne
+    - rid: 2116895650466496528
+      type: {class: MathStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: MathStep
+        inputKey: cardsInHand
+        operand2InputKey: castCountPlusOne
+        operation: 2
+        scale: 0
+        outputKey: damage
+    - rid: 2116895650466496529
+      type: {class: CombatEffectStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatEffectStep
+        inputKey: target
+        combatEffect: 0
+        scale: 0
+        getScaleFromKey: 1
+        inputScaleKey: damage

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Con Artist.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Con Artist.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62bcdaf982dd22e4c896401cbc1745be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Eureka.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Eureka.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
   - rid: 1886371092460208259
   - rid: 1886371092460208257
   - rid: 1886371092460208258
+  effectWorkflows:
+  - rid: 2116895648763871331
   references:
     version: 2
     RefIds:
@@ -52,3 +54,10 @@ MonoBehaviour:
         number: 1
         specialTargetRule: 0
         cantCancelTargetting: 0
+    - rid: 2116895648763871331
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208259
+        - rid: 1886371092460208257
+        - rid: 1886371092460208258

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Force Field.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Force Field.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   effectSteps:
   - rid: 1886371092460208260
   - rid: 1886371092460208261
+  effectWorkflows:
+  - rid: 2116895648763871332
   references:
     version: 2
     RefIds:
@@ -44,3 +46,9 @@ MonoBehaviour:
         scale: 20
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871332
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208260
+        - rid: 1886371092460208261

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Metal Prism.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Metal Prism.asset
@@ -23,6 +23,8 @@ MonoBehaviour:
   - rid: 1886371092460208263
   - rid: 1886371092460208264
   - rid: 1886371092460208265
+  effectWorkflows:
+  - rid: 2116895648763871333
   references:
     version: 2
     RefIds:
@@ -66,3 +68,11 @@ MonoBehaviour:
         scale: 10
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871333
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208262
+        - rid: 1886371092460208263
+        - rid: 1886371092460208264
+        - rid: 1886371092460208265

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Think Fast.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Think Fast.asset
@@ -23,6 +23,8 @@ MonoBehaviour:
   - rid: 1886371092460208267
   - rid: 1886371092460208268
   - rid: 1886371092460208269
+  effectWorkflows:
+  - rid: 2116895648763871334
   references:
     version: 2
     RefIds:
@@ -66,3 +68,11 @@ MonoBehaviour:
         scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871334
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208266
+        - rid: 1886371092460208267
+        - rid: 1886371092460208268
+        - rid: 1886371092460208269

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Tweak Out.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Psychic/Tweak Out.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
   - rid: 1886371092460208270
   - rid: 1886371092460208272
   - rid: 1886371092460208273
+  effectWorkflows:
+  - rid: 2116895648763871335
   references:
     version: 2
     RefIds:
@@ -49,3 +51,10 @@ MonoBehaviour:
         scale: 2
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871335
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208270
+        - rid: 1886371092460208272
+        - rid: 1886371092460208273

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Animate Groteque.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Animate Groteque.asset
@@ -21,9 +21,17 @@ MonoBehaviour:
   effectSteps:
   - rid: 9024302837437038695
   - rid: 9024302837437038696
+  effectWorkflows:
+  - rid: 2116895648763871323
   references:
     version: 2
     RefIds:
+    - rid: 2116895648763871323
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 9024302837437038695
+        - rid: 9024302837437038696
     - rid: 9024302837437038695
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Carrion.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Carrion.asset
@@ -19,6 +19,12 @@ MonoBehaviour:
   vfxPrefab: {fileID: 0}
   playable: 1
   effectSteps: []
+  effectWorkflows:
+  - rid: 2116895648763871324
   references:
     version: 2
-    RefIds: []
+    RefIds:
+    - rid: 2116895648763871324
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps: []

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Frenzy.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Frenzy.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   effectSteps:
   - rid: 1886371092460208275
   - rid: 1886371092460208276
+  effectWorkflows:
+  - rid: 2116895648763871325
   references:
     version: 2
     RefIds:
@@ -44,3 +46,9 @@ MonoBehaviour:
         scale: 3
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871325
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208275
+        - rid: 1886371092460208276

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Hive Mind.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Hive Mind.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   effectSteps:
   - rid: 1886371092460208278
   - rid: 1886371092460208279
+  effectWorkflows:
+  - rid: 2116895648763871326
   references:
     version: 2
     RefIds:
@@ -44,3 +46,9 @@ MonoBehaviour:
         scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871326
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208278
+        - rid: 1886371092460208279

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Mutate.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Mutate.asset
@@ -22,6 +22,8 @@ MonoBehaviour:
   - rid: 1886371092460208280
   - rid: 1886371092460208281
   - rid: 1886371092460208282
+  effectWorkflows:
+  - rid: 2116895648763871327
   references:
     version: 2
     RefIds:
@@ -58,3 +60,10 @@ MonoBehaviour:
         scale: 3
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871327
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208280
+        - rid: 1886371092460208281
+        - rid: 1886371092460208282

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Offering.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/Offering.asset
@@ -24,6 +24,8 @@ MonoBehaviour:
   - rid: 1886371092460208286
   - rid: 1886371092460208284
   - rid: 1886371092460208287
+  effectWorkflows:
+  - rid: 2116895648763871328
   references:
     version: 2
     RefIds:
@@ -74,3 +76,12 @@ MonoBehaviour:
         scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
+    - rid: 2116895648763871328
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208283
+        - rid: 1886371092460208285
+        - rid: 1886371092460208286
+        - rid: 1886371092460208284
+        - rid: 1886371092460208287

--- a/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/SpawnGrotesque.asset
+++ b/Assets/ScriptableObjects/CardTypes/DesignedCards/Street Urchin/SpawnGrotesque.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   effectSteps:
   - rid: 1886371092460208289
   - rid: 1886371092460208288
+  effectWorkflows:
+  - rid: 2116895648763871329
   references:
     version: 2
     RefIds:
@@ -45,3 +47,9 @@ MonoBehaviour:
         number: 1
         specialTargetRule: 4
         cantCancelTargetting: 0
+    - rid: 2116895648763871329
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 1886371092460208289
+        - rid: 1886371092460208288

--- a/Assets/ScriptableObjects/Companions/CompanionTypes/TestCompanions/blocke.asset
+++ b/Assets/ScriptableObjects/Companions/CompanionTypes/TestCompanions/blocke.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96c715ac0cb218d4c9181220c5a8a246, type: 3}
+  m_Name: blocke
+  m_EditorClassIdentifier: 
+  companionName: Beeg Boi
+  maxHealth: 10
+  baseAttackDamage: 0
+  sprite: {fileID: 21300000, guid: bdd59c505b86bf44cabf5f9f82a41064, type: 3}
+  startingDeck: {fileID: 11400000, guid: 955876fe0c18483459bd65e7c6fb9d0a, type: 2}
+  keepsake: {fileID: 21300000, guid: a100f38fb92da834786807cb66e2ebba, type: 3}
+  cardPool: {fileID: 0}
+  ability:
+    rid: 1886370794371285028
+  upgradeInfo: {fileID: 11400000, guid: 99076b48c6110564cb87cbbb29a513b6, type: 2}
+  references:
+    version: 2
+    RefIds:
+    - rid: 1886370794371285028
+      type: {class: CompanionAbility, ns: , asm: Assembly-CSharp}
+      data:
+        companionAbilityTrigger: 0
+        effectSteps: []

--- a/Assets/ScriptableObjects/Companions/CompanionTypes/TestCompanions/blocke.asset.meta
+++ b/Assets/ScriptableObjects/Companions/CompanionTypes/TestCompanions/blocke.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd43e974983001345a0bc96e36057440
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Decks/TestDecks/block.asset
+++ b/Assets/ScriptableObjects/Decks/TestDecks/block.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ede2fa0d5b4eaa44bb6701159a838d3f, type: 3}
+  m_Name: block
+  m_EditorClassIdentifier: 
+  cards:
+  - {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}

--- a/Assets/ScriptableObjects/Decks/TestDecks/block.asset.meta
+++ b/Assets/ScriptableObjects/Decks/TestDecks/block.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 955876fe0c18483459bd65e7c6fb9d0a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Variables/ActiveCompanions.asset
+++ b/Assets/ScriptableObjects/Variables/ActiveCompanions.asset
@@ -13,80 +13,207 @@ MonoBehaviour:
   m_Name: ActiveCompanions
   m_EditorClassIdentifier: 
   companionList:
-  - id: d96e2925-b0a2-4318-875d-10abd14f4b4d
+  - id: 370c7f2d-f891-4eed-880a-40768310dba0
     entityType: 0
-    companionType: {fileID: 11400000, guid: c106de03c6bb3ab4e952724e5e4a073c, type: 2}
-    upgradeInfo: {fileID: 0}
+    companionType: {fileID: 11400000, guid: bb8900a5e0f2ab34a8c486d19dcef389, type: 2}
+    upgradeInfo: {fileID: 11400000, guid: 99076b48c6110564cb87cbbb29a513b6, type: 2}
     deck:
-      startingDeck: {fileID: 11400000, guid: 1e6712d15d797514aa606a6a0d84a059, type: 2}
+      startingDeck: {fileID: 11400000, guid: 10c5c659ceb55d941aaae63b3041edf6, type: 2}
       cards:
-      - id: a82c6788-6421-4d2c-af45-2efcb25b60bb
+      - id: 02d3a32c-14fb-42b4-a9fe-270b7c578cd1
         entityType: 0
-        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
-      - id: ca25c79f-76a1-4d4c-8d82-735504272d82
-        entityType: 0
-        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
-      - id: 0be6f1d7-3913-44b9-b510-54a188ab40db
-        entityType: 0
+        workflowIndex: 0
+        castCount: 0
         cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
-      - id: 80feee88-be52-4442-9663-726900ba49a2
+      - id: 3d38070c-8632-4ee6-b041-c438ff3a0590
         entityType: 0
+        workflowIndex: 0
+        castCount: 0
         cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
-      - id: 9afe630c-e521-465c-8ac4-a78ff90f786b
+      - id: a93b2ef6-a319-42b7-8c19-b6d1f6e2c55d
         entityType: 0
-        cardType: {fileID: 11400000, guid: af631239de690bd4f9c3504152e145d7, type: 2}
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: 3021ad41-d108-4829-99dc-5eec69e9bf34
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: a2d178d4-5c50-49e1-9578-d350901dd6f2
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 29447d4ce5e609b46814ceac547e725f, type: 2}
+      cardsDealtPerTurn: 1
+    combatStats:
+      maxHealth: 30
+      currentHealth: 30
+      baseAttackDamage: 0
+    ability:
+      rid: 2116895649468252219
+  - id: b471ed3b-4eb1-4f1b-8dfe-64b72bfae4b4
+    entityType: 0
+    companionType: {fileID: 11400000, guid: a388cdca9749764489c477a814a4dd5b, type: 2}
+    upgradeInfo: {fileID: 11400000, guid: 99076b48c6110564cb87cbbb29a513b6, type: 2}
+    deck:
+      startingDeck: {fileID: 11400000, guid: 539df5bf5b9a2cf498d76437062d3987, type: 2}
+      cards:
+      - id: ed0efa20-c72c-41d5-9140-5df31ca254b1
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: df89ca75-a527-4ba1-8995-fcb46c2a58ac
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
+      - id: ce5d58a3-e031-4386-af26-19ec807a76fa
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
+      - id: 9f44d1ff-c15f-4176-80bc-e0f4934d0c31
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: f1efe082-3dc3-4ecc-8e2b-1057c98c3244
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 3fe89f2c7b366cb46b2bbe3f4e462aa5, type: 2}
       cardsDealtPerTurn: 1
     combatStats:
       maxHealth: 20
       currentHealth: 20
       baseAttackDamage: 0
     ability:
-      rid: 8939928036647633529
+      rid: 2116895649468252220
+  - id: 0319438f-d315-4d39-abf2-43ab584db37b
+    entityType: 0
+    companionType: {fileID: 11400000, guid: f64c62bd77fcea846a5c19bed998aeb6, type: 2}
+    upgradeInfo: {fileID: 11400000, guid: 99076b48c6110564cb87cbbb29a513b6, type: 2}
+    deck:
+      startingDeck: {fileID: 11400000, guid: 17489518ceb9d7341947bea0c6f7629e, type: 2}
+      cards:
+      - id: 2daeb629-16a1-4621-82d8-c47bf45f89b3
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: 9b8acf86-0e49-45bc-b1f4-ede25677f40f
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
+      - id: ebff5e9e-e579-40b5-9893-44b98467dd6b
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 8f91ac8e9c34b574699f7ab51ed581a6, type: 2}
+      - id: 5507f794-8adf-435f-a7f6-e754ef93ec6c
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: 921440763c921be489a650611fa6cdaf, type: 2}
+      - id: b8cd93f2-f98e-4b68-b743-f274f64152f5
+        entityType: 0
+        workflowIndex: 0
+        castCount: 0
+        cardType: {fileID: 11400000, guid: f47b99629a3e52649bec2a99ec283add, type: 2}
+      cardsDealtPerTurn: 1
+    combatStats:
+      maxHealth: 20
+      currentHealth: 20
+      baseAttackDamage: 0
+    ability:
+      rid: 2116895649468252221
   companionBench: []
   currentCompanionSlots: 3
   references:
     version: 2
     RefIds:
-    - rid: 8939928036647633529
+    - rid: 2116895649468252219
       type: {class: CompanionAbility, ns: , asm: Assembly-CSharp}
       data:
-        companionAbilityTrigger: 2
+        companionAbilityTrigger: 0
         effectSteps:
-        - rid: 8939928036647633530
-        - rid: 8939928036647633531
-        - rid: 8939928036647633532
-        - rid: 8939928036647633533
-    - rid: 8939928036647633530
+        - rid: 2116895649468252222
+        - rid: 2116895649468252223
+    - rid: 2116895649468252220
+      type: {class: CompanionAbility, ns: , asm: Assembly-CSharp}
+      data:
+        companionAbilityTrigger: 4
+        effectSteps:
+        - rid: 2116895649468252224
+        - rid: 2116895649468252225
+    - rid: 2116895649468252221
+      type: {class: CompanionAbility, ns: , asm: Assembly-CSharp}
+      data:
+        companionAbilityTrigger: 3
+        effectSteps:
+        - rid: 2116895649468252226
+        - rid: 2116895649468252227
+    - rid: 2116895649468252222
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:
         effectStepName: GetTargets
         useInputToLimitOptions: 0
         inputKey: 
-        outputKey: allCardsInHand
-        validTargets: 03000000
+        outputKey: self
+        validTargets: 
         number: 1
-        specialTargetRule: 1
+        specialTargetRule: 3
         cantCancelTargetting: 0
-    - rid: 8939928036647633531
-      type: {class: EndWorkflowIfNoMapElement, ns: , asm: Assembly-CSharp}
+    - rid: 2116895649468252223
+      type: {class: SummonMinion, ns: , asm: Assembly-CSharp}
       data:
-        effectStepName: EndWorkflowIfNoMapElement
-        keyToCheck: allCardsInHand
-        mapToCheck: 4
-    - rid: 8939928036647633532
+        effectStepName: SummonMinion
+        minionType: {fileID: 11400000, guid: acf491015f67b06468095238a670ef7b, type: 2}
+        inputKey: self
+        outputKey: 
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 2116895649468252224
       type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:
         effectStepName: GetTargets
         useInputToLimitOptions: 0
         inputKey: 
-        outputKey: cardToRetain
-        validTargets: 03000000
+        outputKey: self
+        validTargets: 
         number: 1
-        specialTargetRule: 0
+        specialTargetRule: 3
         cantCancelTargetting: 0
-    - rid: 8939928036647633533
-      type: {class: CardInHandEffect, ns: , asm: Assembly-CSharp}
+    - rid: 2116895649468252225
+      type: {class: PermanentStatIncrease, ns: , asm: Assembly-CSharp}
       data:
-        effectStepName: CardInHandEffect
-        inputKey: cardToRetain
-        effect: 2
+        effectStepName: PermanentStatIncrease
+        inputKey: self
+        statIncreaseType: 0
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 2116895649468252226
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 3
+        cantCancelTargetting: 0
+    - rid: 2116895649468252227
+      type: {class: PermanentStatIncrease, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: PermanentStatIncrease
+        inputKey: self
+        statIncreaseType: 1
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 

--- a/Assets/Scripts/Cards/Card.cs
+++ b/Assets/Scripts/Cards/Card.cs
@@ -27,6 +27,21 @@ public class Card : Entity, IEquatable<Card>
             return cardType.Artwork;
         }
     }
+
+    [HideInInspector]
+    public List<EffectStep> effectSteps {
+        get {
+            if(cardType.effectWorkflows.Count <= chapter) {
+                Debug.LogError("Attempted to cast chapter " + chapter + " of card " +
+                name + ", but it only has " + (cardType.effectWorkflows.Count + 1) + " chapter(s)");
+            }
+            return cardType.effectWorkflows[chapter - 1].effectSteps;
+        }
+
+    }
+
+    // For sagas, determines the index into the EffectWorkflowList that we'll return from GetEffectWorkflow
+    public int chapter = 1;
     // IMPORTANT TODO: only effects cards that use effectIncreasesOnPlay right now, other things don't poll for this
     // Need to add this into the getEffectScale that's currently in the CasterStats right now
     private Dictionary<CombatEffect, int> effectBuffs = new Dictionary<CombatEffect, int>();

--- a/Assets/Scripts/Cards/Card.cs
+++ b/Assets/Scripts/Cards/Card.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using UnityEngine.Rendering;
 
 [Serializable]
 public class Card : Entity, IEquatable<Card> 
@@ -31,17 +32,19 @@ public class Card : Entity, IEquatable<Card>
     [HideInInspector]
     public List<EffectStep> effectSteps {
         get {
-            if(cardType.effectWorkflows.Count <= chapter) {
-                Debug.LogError("Attempted to cast chapter " + chapter + " of card " +
-                name + ", but it only has " + (cardType.effectWorkflows.Count + 1) + " chapter(s)");
+            if(cardType.effectWorkflows.Count < workflowIndex) {
+                Debug.LogError("Attempted to get workflow " + workflowIndex + " of card " +
+                name + ", but it only has " + (cardType.effectWorkflows.Count + 1) + " workflows");
             }
-            return cardType.effectWorkflows[chapter - 1].effectSteps;
+            return cardType.effectWorkflows[workflowIndex].effectSteps;
         }
 
     }
 
     // For sagas, determines the index into the EffectWorkflowList that we'll return from GetEffectWorkflow
-    public int chapter = 1;
+    // For non-sagas, will always stay at 0
+    private int workflowIndex = 0;
+    public int castCount = 0;
     // IMPORTANT TODO: only effects cards that use effectIncreasesOnPlay right now, other things don't poll for this
     // Need to add this into the getEffectScale that's currently in the CasterStats right now
     private Dictionary<CombatEffect, int> effectBuffs = new Dictionary<CombatEffect, int>();
@@ -130,5 +133,13 @@ public class Card : Entity, IEquatable<Card>
         } else {
             effectBuffs.Add(effect, buff);
         }
+    }
+
+    public int GetWorkflowIndex(){
+        return workflowIndex;
+    }
+
+    public void SetWorkflowIndex(int newIndex){
+        workflowIndex = Mathf.Min(newIndex, cardType.effectWorkflows.Count - 1);
     }
 }

--- a/Assets/Scripts/Cards/CardType.cs
+++ b/Assets/Scripts/Cards/CardType.cs
@@ -18,4 +18,7 @@ public class CardType: ScriptableObject
     public bool playable = true;
     [SerializeReference]
     public List<EffectStep> effectSteps;
+
+    [SerializeReference]
+    public List<EffectWorkflow> effectWorkflows;
 }

--- a/Assets/Scripts/Cards/CardType.cs
+++ b/Assets/Scripts/Cards/CardType.cs
@@ -16,8 +16,6 @@ public class CardType: ScriptableObject
     public GameObject vfxPrefab;
     // For unplayable status cards
     public bool playable = true;
-    [SerializeReference]
-    public List<EffectStep> effectSteps;
 
     [SerializeReference]
     public List<EffectWorkflow> effectWorkflows;

--- a/Assets/Scripts/Cards/PlayableCard.cs
+++ b/Assets/Scripts/Cards/PlayableCard.cs
@@ -50,7 +50,7 @@ public class PlayableCard : MonoBehaviour,
         EffectDocument document = new EffectDocument();
         document.map.AddItem(EffectDocument.ORIGIN, this);
         document.originEntityType = EntityType.Card;
-        EffectManager.Instance.invokeEffectWorkflow(document, card.cardType.effectSteps, CardFinishCastingCallback);
+        EffectManager.Instance.invokeEffectWorkflow(document, card.effectSteps, CardFinishCastingCallback);
     }
 
     private void CardFinishCastingCallback() {

--- a/Assets/Scripts/Cards/PlayableCard.cs
+++ b/Assets/Scripts/Cards/PlayableCard.cs
@@ -57,6 +57,11 @@ public class PlayableCard : MonoBehaviour,
         ManaManager.Instance.updateMana(-card.cost);
         StartCoroutine(cardCastEvent.RaiseAtEndOfFrameCoroutine(new CardCastEventInfo(card)));
         DiscardCardFromHand();
+        IncrementCastCount();
+    }
+
+    private void IncrementCastCount(){
+        card.castCount += 1;
     }
 
     public void DiscardCardFromHand() {

--- a/Assets/Scripts/Effects/EffectStep.cs
+++ b/Assets/Scripts/Effects/EffectStep.cs
@@ -25,7 +25,9 @@ public enum EffectStepName {
     MathStep,
     EndWorkflowIfNoMapElement,
     InstantiatePrefab,
-    CountStatusEffectsStep
+    CountStatusEffectsStep,
+    GetCastCountFromCard,
+    SetCardEffectWorkflow
 }
 
 [System.Serializable]

--- a/Assets/Scripts/Effects/EffectSteps/GetCastCountFromCard.cs
+++ b/Assets/Scripts/Effects/EffectSteps/GetCastCountFromCard.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Playables;
+
+/*
+    Effect that gets the amount of times that a provided card has been cast this encounter
+
+    Inputs: The card
+    Output: The amount of times the card has been cast this encounter
+    Paramters:
+        - countFromThisCard: if checked, will get the cast count of this card
+*/
+public class GetCastCountFromCard : EffectStep {
+    [SerializeField]
+    private string inputKey = "";
+    [SerializeField]
+    private string outputKey = "";
+
+
+    [SerializeField]
+    private bool countFromThisCard = true;
+    public GetCastCountFromCard() {
+        effectStepName = "GetCastCountFromCard";
+    }
+
+    public override IEnumerator invoke(EffectDocument document) {
+        Card card;
+        if (countFromThisCard) {
+            PlayableCard originCard = document.map.GetItem<PlayableCard>(EffectDocument.ORIGIN, 0);
+            if(originCard == null) {
+                Debug.LogError("Can't get cast count from a non-card origin!");
+            }
+            card = originCard.card;
+        } else {
+            card = document.map.GetItem<Card>(inputKey, 0);
+            if (card == null) {
+                Debug.LogError("No card by id " + inputKey + " in effect document");
+            }
+        }
+        document.intMap[outputKey] = card.castCount;
+        yield return null;
+
+
+    }
+
+    private void getCardsFromInCombatDeck(
+            DeckInstance deckInstance,
+            int num,
+            List<Card> cardList) {
+        if (num == 0) {
+            EffectError("Can't get 0 cards from a deck");
+            return;
+        }
+
+        if (deckInstance.drawPile.Count <= num) {
+            cardList.AddRange(deckInstance.drawPile);
+            return;
+        }
+
+        cardList.AddRange(deckInstance.drawPile.GetRange(0, num));
+    }
+}

--- a/Assets/Scripts/Effects/EffectSteps/GetCastCountFromCard.cs.meta
+++ b/Assets/Scripts/Effects/EffectSteps/GetCastCountFromCard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17b2ea78b45518b48b031cce65282e20
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/EffectSteps/MathStep.cs
+++ b/Assets/Scripts/Effects/EffectSteps/MathStep.cs
@@ -4,18 +4,21 @@ using UnityEngine;
 
 
 /*
-    The effect that takes in an int value and does some math operation on it
+    The effect that takes in up to two values and does some math operation on it
 
     Input: An int stored in the effect document
     Output: The int after applying the operation with the given scale
     Parameters:
         - Scale: The fixed scale to use in the other side of the operation
+        - (optional) Operand2: another input to use instead of using a fixed scale
         - Operation: The math operation to do
 */
 public class MathStep: EffectStep
 {
     [SerializeField]
     private string inputKey = "";
+    [SerializeField]
+    private string operand2InputKey = "UNUSED";
     [SerializeField]
     private Operation operation;
     [SerializeField]
@@ -34,23 +37,26 @@ public class MathStep: EffectStep
             yield break;
         }
 
+        bool useOperand2 = document.intMap.ContainsKey(operand2InputKey);
+        int operand2 = 0;
+        if(useOperand2) operand2 = document.intMap[operand2InputKey];
         int inputValue = document.intMap[inputKey];
         int returnValue = inputValue;
         switch (operation) {
             case Operation.Add:
-                returnValue = inputValue + scale;
+                returnValue = useOperand2 ? inputValue + operand2 : inputValue + scale;
             break;
 
             case Operation.Subtract:
-                returnValue = inputValue - scale;
+                returnValue = useOperand2 ? inputValue - operand2 : inputValue - scale;
             break;
 
             case Operation.Multiply:
-                returnValue = inputValue * scale;
+                returnValue = useOperand2 ? inputValue * operand2 : inputValue * scale;
             break;
 
             case Operation.Divide:
-                returnValue = inputValue / scale;
+                returnValue = useOperand2 ? inputValue / operand2 : inputValue / scale;
             break;
         }
 

--- a/Assets/Scripts/Effects/EffectSteps/SetCardEffectWorkflow.cs
+++ b/Assets/Scripts/Effects/EffectSteps/SetCardEffectWorkflow.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Playables;
+
+/*
+    Sets the target card to use a specific effect workflow. Used to advance the chapters of all sagas
+
+    Inputs: The card
+    Output: NA
+    Paramters:
+        - Increment: if checked, will increase the workflowIndex by 1, capping at the amount of workflows present
+        - modifyThisCard: if checked, effect will target the card that cast this
+*/
+public class SetCardEffectWorkflow : EffectStep {
+    [SerializeField]
+    private string cardInputKey = "";
+    [SerializeField]
+    private string chapterInputKey = "";
+
+    [SerializeField]
+    private bool increment = true;
+    [SerializeField]
+    private bool modifyThisCard = true;
+    public SetCardEffectWorkflow() {
+        effectStepName = "SetCardEffectWorkflow";
+    }
+
+    public override IEnumerator invoke(EffectDocument document) {
+        Card card;
+        if (modifyThisCard) {
+            PlayableCard originCard = document.map.GetItem<PlayableCard>(EffectDocument.ORIGIN, 0);
+            if(originCard == null) {
+                Debug.LogError("Can't get cast count from a non-card origin!");
+            }
+            card = originCard.card;
+        } else {
+            card = document.map.GetItem<Card>(cardInputKey, 0);
+            if (card == null) {
+                Debug.LogError("No card by id " + cardInputKey + " in effect document");
+            }
+        }
+        if (increment) {
+            // SetWorkflowIndex handles the possible overflow
+            card.SetWorkflowIndex(card.GetWorkflowIndex() + 1);
+        } else {
+            int chapter = document.intMap[chapterInputKey];
+            card.SetWorkflowIndex(chapter);
+
+        }
+        Debug.Log("new workflow index" + card.GetWorkflowIndex());
+        yield return null;
+
+
+    }
+
+    private void getCardsFromInCombatDeck(
+            DeckInstance deckInstance,
+            int num,
+            List<Card> cardList) {
+        if (num == 0) {
+            EffectError("Can't get 0 cards from a deck");
+            return;
+        }
+
+        if (deckInstance.drawPile.Count <= num) {
+            cardList.AddRange(deckInstance.drawPile);
+            return;
+        }
+
+        cardList.AddRange(deckInstance.drawPile.GetRange(0, num));
+    }
+}

--- a/Assets/Scripts/Effects/EffectSteps/SetCardEffectWorkflow.cs.meta
+++ b/Assets/Scripts/Effects/EffectSteps/SetCardEffectWorkflow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bfbb9ae67e66814b961f3ea28346d12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/EffectWorkflow.cs
+++ b/Assets/Scripts/Effects/EffectWorkflow.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[System.Serializable]
+public class EffectWorkflow
+{
+    [SerializeReference]
+    public List<EffectStep> effectSteps;
+
+    public EffectWorkflow(List<EffectStep> steps = null) {
+        effectSteps = steps == null ? new List<EffectStep>() : new List<EffectStep>(steps);
+    }
+
+}
+

--- a/Assets/Scripts/Effects/EffectWorkflow.cs.meta
+++ b/Assets/Scripts/Effects/EffectWorkflow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36dfc5c5f1de05e4a80934fe6aef94ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Changed cards so that they hold a list of effect workflows instead of just a single list of effect steps. Necessary for sagas!

Migrated all the existing cards using a fun little editor button, check the first commit.

Second commit is where most of the actual action happens. Second commit message:

Implement saga functionality, implement Con Artist

    Added the ability to change the effect workflow a card will use on its
    next cast.

    Tested out this functionality + the cast count functionality on a whole
    ONE saga so you know it has to work.

    Feel free to try it out with the con artist card.

    big TODO: Text box replacement on the cards based on which effect
    workflow is being used, as a stand-in for the special saga card layout
    we'll eventually have. We'll need to store those descriptions for insertion into that layout anyways though.