### PR TITLE
Fix OutOfRange bug + deck selection + stats for combining companions

### DIFF
--- a/Assets/Scripts/Companions/Companion.cs
+++ b/Assets/Scripts/Companions/Companion.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [System.Serializable]
-public class Companion : Entity, ICombatStats, IDeckEntity 
+public class Companion : Entity, ICombatStats, IDeckEntity
 {
     public CompanionTypeSO companionType;
 
@@ -13,7 +13,7 @@ public class Companion : Entity, ICombatStats, IDeckEntity
     [Header("This is here because CompanionInstance doesn't currently exist in the shop")]
     public List<EffectWorkflow> onCombineAbilities = new List<EffectWorkflow>();
 
-    public Companion(CompanionTypeSO companionType) 
+    public Companion(CompanionTypeSO companionType)
     {
         this.companionType = companionType;
         this.combatStats = new CombatStats(
@@ -72,17 +72,18 @@ public class Companion : Entity, ICombatStats, IDeckEntity
     }
 
     public void InvokeOnCombineAbilities() {
-        if(onCombineAbilities != null && onCombineAbilities.Count > 0) {
-            EffectDocument document = new EffectDocument();
-            document.map.AddItem(EffectDocument.ORIGIN, this);
-            document.originEntityType = EntityType.Companion;
-            EffectManager.Instance.invokeEffectWorkflow(document, onCombineAbilities[0], null);
+        if (onCombineAbilities == null) {
+            return;
         }
-        foreach(EffectWorkflow effectWorkflow in onCombineAbilities.GetRange(1, onCombineAbilities.Count - 1)) {
-            EffectDocument document = new EffectDocument();
-            document.map.AddItem(EffectDocument.ORIGIN, this);
-            document.originEntityType = EntityType.Companion;
-            EffectManager.Instance.QueueEffectWorkflow(effectWorkflow);
+        for (int i = 0; i < onCombineAbilities.Count; i++) {
+            if (i == 0) {
+                EffectDocument document = new();
+                document.map.AddItem(EffectDocument.ORIGIN, this);
+                document.originEntityType = EntityType.Companion;
+                EffectManager.Instance.invokeEffectWorkflow(document, onCombineAbilities[i], null);
+            } else {
+                EffectManager.Instance.QueueEffectWorkflow(onCombineAbilities[i]);
+            }
         }
     }
 }

--- a/Assets/Scripts/Encounters/Shop/CompanionCombinationManager.cs
+++ b/Assets/Scripts/Encounters/Shop/CompanionCombinationManager.cs
@@ -65,6 +65,11 @@ public class CompanionCombinationManager : MonoBehaviour
         Companion combinedCompanion = new Companion(companions[0].companionType.upgradeTo);
         combinedCompanion.deck = combinedDeck;
         combinedCompanion.deck.cardsDealtPerTurn = companions[0].companionType.upgradeTo.initialCardsDealtPerTurn;
+
+        combinedCompanion.combatStats.maxHealth = maxHealthForCombinedCompanion(companions);
+        combinedCompanion.combatStats.currentHealth = (int) (combinedCompanion.combatStats.maxHealth * currentHealthPctForCombinedCompanion(companions));
+        combinedCompanion.combatStats.baseAttackDamage = baseAttackDamageForCombinedCompanion(companions);
+
         if(gameState.companions.spaceInActiveCompanions) {
             gameState.companions.activeCompanions.Add(combinedCompanion);
         } else {
@@ -88,5 +93,20 @@ public class CompanionCombinationManager : MonoBehaviour
             }
         }
         return selectedDeck;
+    }
+
+    private int maxHealthForCombinedCompanion(List<Companion> companions) {
+        // Average together the max health of each companion.
+        return (int) companions.Select(c => c.combatStats.maxHealth).ToList().Average();
+    }
+
+    private double currentHealthPctForCombinedCompanion(List<Companion> companions) {
+        // Average together the current health % of each companion.
+        return companions.Select(c => ((double) c.combatStats.currentHealth) / c.combatStats.maxHealth).ToList().Average();
+    }
+
+    private int baseAttackDamageForCombinedCompanion(List<Companion> companions) {
+        // Sum up the base attack damages of each companion.
+        return companions.Select(c => c.combatStats.baseAttackDamage).ToList().Sum();
     }
 }

--- a/Assets/Scripts/Encounters/Shop/CompanionCombinationManager.cs
+++ b/Assets/Scripts/Encounters/Shop/CompanionCombinationManager.cs
@@ -22,9 +22,9 @@ public class CompanionCombinationManager : MonoBehaviour
 
     [SerializeField]
     private GameObject celebrationParticles;
-     
+
     public bool AttemptUpgradeCompanion(Companion purchasedCompanion) {
-        
+
         List<Companion> companions = CompanionsOfType(purchasedCompanion.companionType);
         // Add the one that was just purchased
         companions.Add(purchasedCompanion);
@@ -58,8 +58,13 @@ public class CompanionCombinationManager : MonoBehaviour
                 gameState.companions.benchedCompanions.Remove(c);
             }
         }
+
+        Deck combinedDeck = selectDeckForCombinedCompanions(companions);
+
         // TODO: change this combined companion with whatever mechanics ends up wanting
         Companion combinedCompanion = new Companion(companions[0].companionType.upgradeTo);
+        combinedCompanion.deck = combinedDeck;
+        combinedCompanion.deck.cardsDealtPerTurn = companions[0].companionType.upgradeTo.initialCardsDealtPerTurn;
         if(gameState.companions.spaceInActiveCompanions) {
             gameState.companions.activeCompanions.Add(combinedCompanion);
         } else {
@@ -69,5 +74,19 @@ public class CompanionCombinationManager : MonoBehaviour
 
     private List<Companion> CompanionsOfType(CompanionTypeSO companionType) {
         return gameState.companions.allCompanions.FindAll(c => c.companionType == companionType);
+    }
+
+    private Deck selectDeckForCombinedCompanions(List<Companion> companions) {
+        // TODO(): Allow the player to choose which deck they want to use.
+        // For now, select the largest deck, because presumably that will contain
+        // the most cards the player bought.
+        // It should be a good heuristic for now.
+        Deck selectedDeck = companions[0].deck;
+        for (int i = 1; i < companions.Count; i++) {
+            if (companions[i].deck.cards.Count > selectedDeck.cards.Count) {
+                selectedDeck = companions[i].deck;
+            }
+        }
+        return selectedDeck;
     }
 }


### PR DESCRIPTION
There is a slight bug in the code, I got a count OutOfRange bug in the code off of main. Fixed that.

I also made it automatically select the deck that is the largest out of the companions being combined.
That means that you will get the one you added the most shop cards to, which should be a decent proxy for what we are going for.

Tests:
combined my bidoofs into a gloriously big l2 bidoof