### PR TITLE
Add upgrade button tooltips in the shop

### DIFF
--- a/Assets/Scenes/Encounters/PlaceholderShopEncounter.unity
+++ b/Assets/Scenes/Encounters/PlaceholderShopEncounter.unity
@@ -872,10 +872,57 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 769442872913067365, guid: 46876332ab8dd8b4a8efc1e901b565f0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4573181857404763394}
+    - targetCorrespondingSourceObject: {fileID: 769442872913067365, guid: 46876332ab8dd8b4a8efc1e901b565f0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4573181857404763395}
     - targetCorrespondingSourceObject: {fileID: 624278721722885037, guid: 46876332ab8dd8b4a8efc1e901b565f0, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 46876332ab8dd8b4a8efc1e901b565f0, type: 3}
+--- !u!1 &4573181857404763393 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 769442872913067365, guid: 46876332ab8dd8b4a8efc1e901b565f0, type: 3}
+  m_PrefabInstance: {fileID: 4573181857404763392}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4573181857404763394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4573181857404763393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 047152731ba5f1943a7c416983ad68e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltipPrefab: {fileID: 2816874809441598624, guid: 39e007ab3d5dc2a489824af9da1f4bae, type: 3}
+  tooltip:
+    rid: -2
+  positionOffset: {x: 0, y: 0, z: 0}
+  displayWaitTime: 0.5
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+--- !u!114 &4573181857404763395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4573181857404763393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10d95b06956ca45998f3e97be62b9727, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shopData: {fileID: 11400000, guid: 64b1d5221aac20348909c6cab7cc24d6, type: 2}
+  playerData: {fileID: 11400000, guid: 04fd9f244e2a13e4d9e28d6e1a2f7a9a, type: 2}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Encounters/BaseShopData.asset
+++ b/Assets/ScriptableObjects/Encounters/BaseShopData.asset
@@ -25,6 +25,12 @@ MonoBehaviour:
     commonCardPercentage: 90
     uncommonCardPercentage: 10
     rareCardPercentage: 0
+    upgradeTooltip:
+      empty: 0
+      lines:
+      - title: Upgrade to Level 2
+        description: +1 team size, increase shop rarity
+        image: {fileID: 0}
   - level: 1
     mana: 3
     teamSize: 4
@@ -35,8 +41,14 @@ MonoBehaviour:
     uncommonCompanionPercentage: 28
     rareCompanionPercentage: 2
     commonCardPercentage: 70
-    uncommonCardPercentage: 28
-    rareCardPercentage: 2
+    uncommonCardPercentage: 25
+    rareCardPercentage: 5
+    upgradeTooltip:
+      empty: 0
+      lines:
+      - title: Upgrade to Level 3
+        description: +1 mana, increase shop rarity
+        image: {fileID: 0}
   - level: 2
     mana: 4
     teamSize: 4
@@ -49,6 +61,12 @@ MonoBehaviour:
     commonCardPercentage: 50
     uncommonCardPercentage: 40
     rareCardPercentage: 10
+    upgradeTooltip:
+      empty: 0
+      lines:
+      - title: Upgrade to Level 4
+        description: +1 team size, increase shop rarity
+        image: {fileID: 0}
   - level: 3
     mana: 4
     teamSize: 5
@@ -61,6 +79,9 @@ MonoBehaviour:
     commonCardPercentage: 30
     uncommonCardPercentage: 40
     rareCardPercentage: 30
+    upgradeTooltip:
+      empty: 0
+      lines: []
   companionPool: {fileID: 11400000, guid: 4113f0ac393ad43499c4e9e9a4e6d97e, type: 2}
   rerollShopPrice: 2
   shopEncounterEvent: {fileID: 11400000, guid: d82ee33fc33d20544bce205c53a0832e, type: 2}

--- a/Assets/Scripts/Encounters/Shop/ShopDataSO.cs
+++ b/Assets/Scripts/Encounters/Shop/ShopDataSO.cs
@@ -54,6 +54,10 @@ public class ShopLevel {
     public int uncommonCardPercentage;
     public int rareCardPercentage;
 
+    [Space(10)]
+    [Header("Help the player understand this shit")]
+    public TooltipViewModel upgradeTooltip;
+
     public int GetTotalCompanionPercentage() {
         return commonCompanionPercentage +
             uncommonCompanionPercentage +

--- a/Assets/Scripts/Encounters/Shop/ShopManager.cs
+++ b/Assets/Scripts/Encounters/Shop/ShopManager.cs
@@ -183,6 +183,7 @@ public class ShopManager : GenericSingleton<ShopManager>, IEncounterBuilder
             gameState.companions.SetCompanionSlots(shopLevel.teamSize);
             playerData.manaPerTurn = shopLevel.mana;
 
+            shopUIManager.RefreshUpgradeButtonTooltip();
             CheckDisableUpgradeButton();
         } else {
             shopUIManager.displayNeedMoreMoneyNotification();

--- a/Assets/Scripts/UI/ShopUIManager.cs
+++ b/Assets/Scripts/UI/ShopUIManager.cs
@@ -38,6 +38,11 @@ public class ShopUIManager : GenericSingleton<ShopUIManager>
         upgradeShopButtonGoldText.gameObject.SetActive(false);
     }
 
+    public void RefreshUpgradeButtonTooltip() {
+        UpgradeButtonTooltipProvider provider = upgradeButton.GetComponent<UpgradeButtonTooltipProvider>();
+        provider.RefreshTooltip();
+    }
+
     public void displayNeedMoreMoneyNotification() {
         StartCoroutine("displayNeedMoreMoneyText");
     }

--- a/Assets/Scripts/UI/Tooltips/UpgradeButtonTooltipProvider.cs
+++ b/Assets/Scripts/UI/Tooltips/UpgradeButtonTooltipProvider.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.EventSystems;
+using UnityEditor;
+
+public class UpgradeButtonTooltipProvider : MonoBehaviour
+{
+    private TooltipOnHover tooltipOnHover;
+
+    public ShopDataSO shopData;
+
+    public PlayerDataVariableSO playerData;
+    void Start() {
+        RefreshTooltip();
+    }
+
+    // Make it easy to refresh the tooltip, because we want to reload it after the
+    // shop level changes.
+    public void RefreshTooltip() {
+        tooltipOnHover = GetComponent<TooltipOnHover>();
+        tooltipOnHover.tooltip = new TooltipViewModel();
+        ShopLevel level = shopData.GetShopLevel(playerData.GetValue().shopLevel);
+        tooltipOnHover.tooltip += level.upgradeTooltip;
+    }
+}

--- a/Assets/Scripts/UI/Tooltips/UpgradeButtonTooltipProvider.cs.meta
+++ b/Assets/Scripts/UI/Tooltips/UpgradeButtonTooltipProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10d95b06956ca45998f3e97be62b9727
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The upgrade button is opaque to the player.
The tooltip gives a better idea of what it will do; change the team size, the mana, and the rarity of shop offerings.