### PR TITLE
Assign cards based on CardPoolSO instead of CompanionTypeSO

### DIFF
--- a/Assets/Scripts/Encounters/Shop/ShopManager.cs
+++ b/Assets/Scripts/Encounters/Shop/ShopManager.cs
@@ -92,7 +92,9 @@ public class ShopManager : GenericSingleton<ShopManager>, IEncounterBuilder
             CompanionTypeSO cardSourceCompanion = cardInfo.getCompanionFrom();
             // Source companion will be null if the card is neutral; in that case, we should include all
             // companions.
-            if (cardSourceCompanion == null || cardSourceCompanion == companion.companionType) {
+            // Also, do it based on card pool so the same card can be assigned to a
+            // level 1 or level 2 companion of the same type.
+            if (cardSourceCompanion == null || cardSourceCompanion.cardPool == companion.companionType.cardPool) {
                 companionList.Add(companion);
             }
         }
@@ -109,7 +111,9 @@ public class ShopManager : GenericSingleton<ShopManager>, IEncounterBuilder
             CompanionTypeSO cardSourceCompanion = cardInfo.getCompanionFrom();
             // Source companion will be null if the card is neutral; in that case, we should include all
             // companions.
-            if (cardSourceCompanion == null || cardSourceCompanion == companion.companionType) {
+            // Also, do it based on card pool so the same card can be assigned to a
+            // level 1 or level 2 companion of the same type.
+            if (cardSourceCompanion == null || cardSourceCompanion.cardPool == companion.companionType.cardPool) {
                 companionList.Add(companion);
             }
         }


### PR DESCRIPTION
When you have a Level1 and level2 companion of the same type, the card purchasing in the shop gets weird.
The behavior we want is that the card pools for the both are the same, and cards can be assigned to either level1 or level2. It was especially annoying when you upgraded a companion and then tried to buy a card that was in the shop - you couldn't until you refreshed. This fixes that problem.

Test: tried it out