### PR TITLE
Tentative fix for effects not resolving before turn phases change

### DIFF
--- a/Assets/Scripts/GameplayManagement/TurnManager.cs
+++ b/Assets/Scripts/GameplayManagement/TurnManager.cs
@@ -80,6 +80,12 @@ public class TurnManager : GenericSingleton<TurnManager>
     private IEnumerator nextPhaseAfterTriggers(TurnPhase currentPhase) {
         Debug.Log("nextPhaseAfterTriggers found " + turnPhaseTriggers[currentPhase].Count + " triggers for phase " + currentPhase);
         yield return StartCoroutine(runTriggersForPhase(currentPhase));
+        // Wait for effects to resolve before raising the next turn phase event.
+        // We need to do this because many of the "runTriggersForPhase" in the game
+        // right now are not managed as coroutines.
+        // Otherwise, we could wait on them all to complete with only the `yield return StartCoroutine`
+        // expression.
+        yield return new WaitUntil(() => EffectManager.Instance.IsEffectRunning() == false);
         StartCoroutine(turnPhaseEvent.RaiseAtEndOfFrameCoroutine(new TurnPhaseEventInfo(nextPhase[currentPhase])));
     }
 

--- a/Assets/Scripts/GameplayManagement/TurnManager.cs
+++ b/Assets/Scripts/GameplayManagement/TurnManager.cs
@@ -85,6 +85,8 @@ public class TurnManager : GenericSingleton<TurnManager>
         // right now are not managed as coroutines.
         // Otherwise, we could wait on them all to complete with only the `yield return StartCoroutine`
         // expression.
+        // Note: this is a lil racy, it depends on the EffectManager being marked as running
+        // by another coroutine before this coroutine resumes and checks; not foolproof.
         yield return new WaitUntil(() => EffectManager.Instance.IsEffectRunning() == false);
         StartCoroutine(turnPhaseEvent.RaiseAtEndOfFrameCoroutine(new TurnPhaseEventInfo(nextPhase[currentPhase])));
     }


### PR DESCRIPTION
We have a few effect workflows that trigger when the turn phase changes, including the Fireblob cards dealing damage at the end of combat. Ethan noticed that the game would freak out a lil when the fireblob dealt fatal damage. The combat would end, but the end of combat abilities would be cleared out by the turn starting.
This should be an effective bandaid for now - I tested it out. The current code does not work, because some of the coroutines we start do the naked `StartCoroutine` instead of `yield return StartCoroutine`, so some of the effects that we are trying to wait on are not part of the parent-child hierarchy.

Cheers,
James