### PR TITLE
Essence Feeder - every 4 cards, gain 1 strength

### DIFF
--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Act2EliteEnemyPool.asset
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Act2EliteEnemyPool.asset
@@ -14,3 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enemyEncounterTypes:
   - {fileID: 11400000, guid: 1f911ca649faa4f67958191768633400, type: 2}
+  - {fileID: 11400000, guid: dff959dc3cbfc45edbd05832718be96b, type: 2}

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Enc_EssenceFeeder.asset
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Enc_EssenceFeeder.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17a7027b6d1213c4fa7f5d4be961eaab, type: 3}
+  m_Name: Enc_EssenceFeeder
+  m_EditorClassIdentifier: 
+  enemies:
+  - {fileID: 11400000, guid: 25c20719d14744352ba0915c063f17e4, type: 2}
+  devNotes: 

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Enc_EssenceFeeder.asset.meta
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/Enc_EssenceFeeder.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dff959dc3cbfc45edbd05832718be96b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   sprite: {fileID: 21300000, guid: 389ae5e98571d08419b91177b86e2642, type: 3}
   abilities:
   - rid: 205828126246961421
-  - rid: 205828126246961455
+  - rid: 205828126246961568
   enemyPattern:
     behaviors: []
     behaviorType: 0
@@ -31,7 +31,7 @@ MonoBehaviour:
     empty: 0
     lines:
     - title: Feeding Frenzy
-      description: Whenever you play 4 cards in a turn, this gains 1 strength!
+      description: Every time you play 4 cards, this gains 1 strength!
       relatedBehaviorIndex: 0
   references:
     version: 2
@@ -51,37 +51,6 @@ MonoBehaviour:
         - rid: 205828126246961465
         - rid: 205828126246961466
         - rid: 205828126246961467
-    - rid: 205828126246961455
-      type: {class: EntityAbility, ns: , asm: Assembly-CSharp}
-      data:
-        abilityTrigger: 12
-        effectSteps:
-        - rid: 205828126246961457
-        - rid: 205828126246961456
-    - rid: 205828126246961456
-      type: {class: CombatInstanceCacheStore, ns: , asm: Assembly-CSharp}
-      data:
-        effectStepName: CombatInstanceCacheStore
-        inputCombatInstanceKey: self
-        hardCodedBool: 0
-        useHardCodedBool: 0
-        hardCodedInt: 0
-        useHardCodedInt: 1
-        hardCodedString: 
-        useHardCodedString: 0
-        currentWorkflowKey: 
-        cacheKey: numCardsPlayed
-    - rid: 205828126246961457
-      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
-      data:
-        effectStepName: GetTargets
-        useInputToLimitOptions: 0
-        inputKey: 
-        outputKey: self
-        validTargets: 
-        number: 1
-        specialTargetRule: 3
-        cantCancelTargetting: 0
     - rid: 205828126246961458
       type: {class: CombatInstanceCacheLoad, ns: , asm: Assembly-CSharp}
       data:
@@ -146,7 +115,7 @@ MonoBehaviour:
       data:
         effectStepName: EndWorkflowIfConditionMet
         inputKey1: atLeastFourCardsPlayed
-        conditionToEndOn: 1
+        conditionToEndOn: 0
     - rid: 205828126246961465
       type: {class: ApplyStatus, ns: , asm: Assembly-CSharp}
       data:
@@ -177,3 +146,34 @@ MonoBehaviour:
         inputKey: self
         prefabToInstantiate: {fileID: 2729960547564495472, guid: a6a1a26d43bc7114eba88909bdbfccc7, type: 3}
         scale: 1
+    - rid: 205828126246961568
+      type: {class: EntityAbility, ns: , asm: Assembly-CSharp}
+      data:
+        abilityTrigger: 0
+        effectSteps:
+        - rid: 205828126246961569
+        - rid: 205828126246961570
+    - rid: 205828126246961569
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 3
+        cantCancelTargetting: 0
+    - rid: 205828126246961570
+      type: {class: CombatInstanceCacheStore, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatInstanceCacheStore
+        inputCombatInstanceKey: self
+        hardCodedBool: 0
+        useHardCodedBool: 0
+        hardCodedInt: 0
+        useHardCodedInt: 1
+        hardCodedString: 
+        useHardCodedString: 0
+        currentWorkflowKey: 
+        cacheKey: numCardsPlayed

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
@@ -1,0 +1,179 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c75450655d80cac4ea4b0c2e3c0e01f3, type: 3}
+  m_Name: EssenceFeeder
+  m_EditorClassIdentifier: 
+  maxHealth: 200
+  baseAttackDamage: 0
+  sprite: {fileID: 21300000, guid: 389ae5e98571d08419b91177b86e2642, type: 3}
+  abilities:
+  - rid: 205828126246961421
+  - rid: 205828126246961455
+  enemyPattern:
+    behaviors: []
+    behaviorType: 0
+    nextBehaviorIndex: 0
+  belowHalfHPEnemyPattern:
+    behaviors: []
+    behaviorType: 0
+    nextBehaviorIndex: 0
+  initialStatuses: []
+  tooltip:
+    empty: 0
+    lines:
+    - title: Feeding Frenzy
+      description: Whenever you play 4 cards in a turn, this gains 1 strength!
+      relatedBehaviorIndex: 0
+  references:
+    version: 2
+    RefIds:
+    - rid: 205828126246961421
+      type: {class: EntityAbility, ns: , asm: Assembly-CSharp}
+      data:
+        abilityTrigger: 7
+        effectSteps:
+        - rid: 205828126246961459
+        - rid: 205828126246961458
+        - rid: 205828126246961460
+        - rid: 205828126246961461
+        - rid: 205828126246961462
+        - rid: 205828126246961463
+        - rid: 205828126246961464
+        - rid: 205828126246961465
+        - rid: 205828126246961466
+        - rid: 205828126246961467
+    - rid: 205828126246961455
+      type: {class: EntityAbility, ns: , asm: Assembly-CSharp}
+      data:
+        abilityTrigger: 12
+        effectSteps:
+        - rid: 205828126246961457
+        - rid: 205828126246961456
+    - rid: 205828126246961456
+      type: {class: CombatInstanceCacheStore, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatInstanceCacheStore
+        inputCombatInstanceKey: self
+        hardCodedBool: 0
+        useHardCodedBool: 0
+        hardCodedInt: 0
+        useHardCodedInt: 1
+        hardCodedString: 
+        useHardCodedString: 0
+        currentWorkflowKey: 
+        cacheKey: numCardsPlayed
+    - rid: 205828126246961457
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 3
+        cantCancelTargetting: 0
+    - rid: 205828126246961458
+      type: {class: CombatInstanceCacheLoad, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatInstanceCacheLoad
+        inputCombatInstanceKey: self
+        cacheKey: numCardsPlayed
+        currentWorkflowKey: numCardsPlayed
+    - rid: 205828126246961459
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 3
+        cantCancelTargetting: 0
+    - rid: 205828126246961460
+      type: {class: MathStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: MathStep
+        inputKey: numCardsPlayed
+        operand2InputKey: UNUSED
+        operation: 0
+        scale: 1
+        outputKey: updatedNumCardsPlayed
+    - rid: 205828126246961461
+      type: {class: CombatInstanceCacheStore, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatInstanceCacheStore
+        inputCombatInstanceKey: self
+        hardCodedBool: 0
+        useHardCodedBool: 0
+        hardCodedInt: 0
+        useHardCodedInt: 0
+        hardCodedString: 
+        useHardCodedString: 0
+        currentWorkflowKey: updatedNumCardsPlayed
+        cacheKey: numCardsPlayed
+    - rid: 205828126246961462
+      type: {class: DebugEffectStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DebugEffectStep
+        inputCombatInstanceCacheKey: self
+        genericMap: 0
+        ints: 1
+        strings: 1
+        bools: 0
+    - rid: 205828126246961463
+      type: {class: BooleanComparison, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: BooleanComparison
+        hardCodedInputKey1: 4
+        useHardCodedInputKey1: 1
+        inputKey1: 
+        operation: 2
+        inputKey2: updatedNumCardsPlayed
+        outputKey: atLeastFourCardsPlayed
+    - rid: 205828126246961464
+      type: {class: EndWorkflowIfConditionMet, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: EndWorkflowIfConditionMet
+        inputKey1: atLeastFourCardsPlayed
+        conditionToEndOn: 1
+    - rid: 205828126246961465
+      type: {class: ApplyStatus, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: ApplyStatus
+        inputKey: self
+        statusEffect: 0
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+        multiplyByNumAuraStacks: 0
+    - rid: 205828126246961466
+      type: {class: CombatInstanceCacheStore, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatInstanceCacheStore
+        inputCombatInstanceKey: self
+        hardCodedBool: 0
+        useHardCodedBool: 0
+        hardCodedInt: 0
+        useHardCodedInt: 1
+        hardCodedString: 
+        useHardCodedString: 0
+        currentWorkflowKey: 
+        cacheKey: numCardsPlayed
+    - rid: 205828126246961467
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: self
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: a6a1a26d43bc7114eba88909bdbfccc7, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset
@@ -19,7 +19,15 @@ MonoBehaviour:
   - rid: 205828126246961421
   - rid: 205828126246961568
   enemyPattern:
-    behaviors: []
+    behaviors:
+    - intent: 0
+      enemyTargetMethod: 0
+      targetsKey: target
+      displayValue: 1
+      effectSteps:
+      - rid: 205828126246961605
+      - rid: 205828126246961606
+      - rid: 205828126246961607
     behaviorType: 0
     nextBehaviorIndex: 0
   belowHalfHPEnemyPattern:
@@ -177,3 +185,41 @@ MonoBehaviour:
         useHardCodedString: 0
         currentWorkflowKey: 
         cacheKey: numCardsPlayed
+    - rid: 205828126246961605
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 3
+        cantCancelTargetting: 0
+    - rid: 205828126246961606
+      type: {class: CombatEffectStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CombatEffectStep
+        inputKey: target
+        combatEffect: 0
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+        multiplicity: 1
+        getMultiplicityFromKey: 0
+        inputMultiplicityKey: 
+    - rid: 205828126246961607
+      type: {class: FXEffectStep, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: FXEffectStep
+        waitForEffect: 1
+        fXExperiencePrefab: {fileID: 7374988516867921400, guid: 080ebf6cafefa59438cf877ee502d109, type: 3}
+        rootLocationGameObjectKey: 
+        positionMappingList:
+        - fromWorkflow: self
+          toFxExperience: enemyLocation
+        - fromWorkflow: target
+          toFxExperience: companionLocation
+        gameobjectMappingList:
+        - fromWorkflow: self
+          toFxExperience: enemy

--- a/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset.meta
+++ b/Assets/ScriptableObjects/Map/GhoulGauntlet/Act2Elite/EssenceFeeder.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25c20719d14744352ba0915c063f17e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/EffectDocument.cs
+++ b/Assets/Scripts/Effects/EffectDocument.cs
@@ -43,6 +43,12 @@ public class EffectDocument
         }
     }
 
+    public void printBoolMap() {
+        foreach (KeyValuePair<string, bool> pair in boolMap) {
+            Debug.Log("Key: " + pair.Key + "\nvalue: " + pair.Value.ToString());
+        }
+    }
+
     public class GenericListDictionary {
         private Dictionary<Tuple<string, Type>, List<object>> _dict = new Dictionary<Tuple<string, Type>, List<object>>();
         private Dictionary<Tuple<string, Type>, string> _linkDict = new Dictionary<Tuple<string, Type>, string>();

--- a/Assets/Scripts/Effects/EffectStep.cs
+++ b/Assets/Scripts/Effects/EffectStep.cs
@@ -12,6 +12,8 @@ public enum EffectStepName {
     CardModificationEffect,
     CheckTypeOfMostRecentlyPlayedCard,
     CombatEffectStep,
+    CombatInstanceCacheLoad,
+    CombatInstanceCacheStore,
     ConvertPlayableCardToCard,
     ConvertPlayableCardToDeckInstance,
     CountCardsInDeck,

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/*
+    Effect that loads a value into the current effect document from the
+    cached effect document attached to the combat instance.
+
+    It assumes the type from which map the key is stored in.
+    Only allows loading primitive values for now.
+*/
+public class CombatInstanceCacheLoad : EffectStep
+{
+    [SerializeField]
+    private string inputCombatInstanceKey = "";
+
+    [SerializeField]
+    private string cacheKey = "";
+
+    [SerializeField]
+    private string currentWorkflowKey = "";
+
+    public CombatInstanceCacheLoad() {
+        effectStepName = "CombatInstanceCacheLoad";
+    }
+
+    public override IEnumerator invoke(EffectDocument document) {
+        List<CombatInstance> instances = document.map.GetList<CombatInstance>(inputCombatInstanceKey);
+        if (instances.Count == 0) {
+            EffectError("No input targets present for key " + inputCombatInstanceKey);
+            yield break;
+        }
+        if (instances.Count > 1) {
+            EffectError("Too many input targets for key " + inputCombatInstanceKey + ", only 1 allowed instead have " + instances.Count.ToString());
+            yield break;
+        }
+        CombatInstance target = instances[0];
+
+        bool isBool = target.cachedEffectValues.boolMap.ContainsKey(cacheKey);
+        bool isInt = target.cachedEffectValues.intMap.ContainsKey(cacheKey);
+        bool isString = target.cachedEffectValues.stringMap.ContainsKey(cacheKey);
+        int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt) + Convert.ToInt32(isString);
+        if (sum == 0) {
+            EffectError("Cache key [" + currentWorkflowKey + "] not found in the bool, string, or int map");
+            yield break;
+        }
+        if (sum > 1) {
+            EffectError("Cache key [" + currentWorkflowKey + "] ambiguous because it exists in multiple maps, breaking!!!");
+            yield break;
+        }
+        if (isBool) {
+            document.boolMap[currentWorkflowKey] = target.cachedEffectValues.boolMap[cacheKey];
+        }
+        if (isInt) {
+            document.intMap[currentWorkflowKey] = target.cachedEffectValues.intMap[cacheKey];
+        }
+        if (isString) {
+            document.stringMap[currentWorkflowKey] = target.cachedEffectValues.stringMap[cacheKey];
+        }
+    }
+}

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs
@@ -39,10 +39,9 @@ public class CombatInstanceCacheLoad : EffectStep
 
         bool isBool = target.cachedEffectValues.boolMap.ContainsKey(cacheKey);
         bool isInt = target.cachedEffectValues.intMap.ContainsKey(cacheKey);
-        bool isString = target.cachedEffectValues.stringMap.ContainsKey(cacheKey);
-        int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt) + Convert.ToInt32(isString);
+        int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt);
         if (sum == 0) {
-            EffectError("Cache key [" + currentWorkflowKey + "] not found in the bool, string, or int map");
+            EffectError("Cache key [" + currentWorkflowKey + "] not found in the bool or int map");
             yield break;
         }
         if (sum > 1) {
@@ -54,9 +53,6 @@ public class CombatInstanceCacheLoad : EffectStep
         }
         if (isInt) {
             document.intMap[currentWorkflowKey] = target.cachedEffectValues.intMap[cacheKey];
-        }
-        if (isString) {
-            document.stringMap[currentWorkflowKey] = target.cachedEffectValues.stringMap[cacheKey];
         }
     }
 }

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs.meta
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheLoad.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f821796ea0bf4251b01d138918d0f12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs
@@ -30,13 +30,6 @@ public class CombatInstanceCacheStore : EffectStep
     private bool useHardCodedInt = false;
 
     [SerializeField]
-    private string hardCodedString = "";
-
-    [SerializeField]
-    private bool useHardCodedString = false;
-
-
-    [SerializeField]
     private string currentWorkflowKey = "";
 
     [SerializeField]
@@ -59,16 +52,15 @@ public class CombatInstanceCacheStore : EffectStep
         CombatInstance target = instances[0];
 
         // Start with the hard-coded values, and if those are not specified, fallback to the current workflow key.
-        int hardCodeSum = Convert.ToInt32(useHardCodedBool) + Convert.ToInt32(useHardCodedInt) + Convert.ToInt32(useHardCodedString);
+        int hardCodeSum = Convert.ToInt32(useHardCodedBool) + Convert.ToInt32(useHardCodedInt);
         if (hardCodeSum == 0) {
             // Now we attempt to use the current workflow key.
             bool isBool = document.boolMap.ContainsKey(currentWorkflowKey);
             bool isInt = document.intMap.ContainsKey(currentWorkflowKey);
-            bool isString = document.stringMap.ContainsKey(currentWorkflowKey);
 
-            int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt) + Convert.ToInt32(isString);
+            int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt);
             if (sum == 0) {
-                EffectError("Current workflow key [" + currentWorkflowKey + "] not found in the bool, string, or int map");
+                EffectError("Current workflow key [" + currentWorkflowKey + "] not found in the bool or int map");
                 yield break;
             }
             if (sum > 1) {
@@ -81,9 +73,6 @@ public class CombatInstanceCacheStore : EffectStep
             if (isInt) {
                 target.cachedEffectValues.intMap[cacheKey] = document.intMap[currentWorkflowKey];
             }
-            if (isString) {
-                target.cachedEffectValues.stringMap[cacheKey] = document.stringMap[currentWorkflowKey];
-            }
             yield break;
         }
 
@@ -92,9 +81,6 @@ public class CombatInstanceCacheStore : EffectStep
         }
         if (useHardCodedInt) {
             target.cachedEffectValues.intMap[cacheKey] = hardCodedInt;
-        }
-        if (useHardCodedString) {
-            target.cachedEffectValues.stringMap[cacheKey] = hardCodedString;
         }
     }
 }

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+/*
+    Effect that stores a value into the cache on the combat instance from the
+    current effect document.
+
+    It assumes the type from which map the key is stored in.
+    Only allows storing primitive values for now.
+*/
+public class CombatInstanceCacheStore : EffectStep
+{
+    [SerializeField]
+    private string inputCombatInstanceKey = "";
+
+
+    [SerializeField]
+    private bool hardCodedBool = false;
+
+    [SerializeField]
+    private bool useHardCodedBool = false;
+
+    [SerializeField]
+    private int hardCodedInt = 0;
+
+    [SerializeField]
+    private bool useHardCodedInt = false;
+
+    [SerializeField]
+    private string hardCodedString = "";
+
+    [SerializeField]
+    private bool useHardCodedString = false;
+
+
+    [SerializeField]
+    private string currentWorkflowKey = "";
+
+    [SerializeField]
+    private string cacheKey = "";
+
+    public CombatInstanceCacheStore() {
+        effectStepName = "CombatInstanceCacheStore";
+    }
+
+    public override IEnumerator invoke(EffectDocument document) {
+        List<CombatInstance> instances = document.map.GetList<CombatInstance>(inputCombatInstanceKey);
+        if (instances.Count == 0) {
+            EffectError("No input targets present for key " + inputCombatInstanceKey);
+            yield break;
+        }
+        if (instances.Count > 1) {
+            EffectError("Too many input targets for key " + inputCombatInstanceKey + ", only 1 allowed instead have " + instances.Count.ToString());
+            yield break;
+        }
+        CombatInstance target = instances[0];
+
+        // Start with the hard-coded values, and if those are not specified, fallback to the current workflow key.
+        int hardCodeSum = Convert.ToInt32(useHardCodedBool) + Convert.ToInt32(useHardCodedInt) + Convert.ToInt32(useHardCodedString);
+        if (hardCodeSum == 0) {
+            // Now we attempt to use the current workflow key.
+            bool isBool = document.boolMap.ContainsKey(currentWorkflowKey);
+            bool isInt = document.intMap.ContainsKey(currentWorkflowKey);
+            bool isString = document.stringMap.ContainsKey(currentWorkflowKey);
+
+            int sum = Convert.ToInt32(isBool) + Convert.ToInt32(isInt) + Convert.ToInt32(isString);
+            if (sum == 0) {
+                EffectError("Current workflow key [" + currentWorkflowKey + "] not found in the bool, string, or int map");
+                yield break;
+            }
+            if (sum > 1) {
+                EffectError("Current workflow key [" + currentWorkflowKey + "] ambiguous because it exists in multiple maps, breaking!!!");
+                yield break;
+            }
+            if (isBool) {
+                target.cachedEffectValues.boolMap[cacheKey] = document.boolMap[currentWorkflowKey];
+            }
+            if (isInt) {
+                target.cachedEffectValues.intMap[cacheKey] = document.intMap[currentWorkflowKey];
+            }
+            if (isString) {
+                target.cachedEffectValues.stringMap[cacheKey] = document.stringMap[currentWorkflowKey];
+            }
+            yield break;
+        }
+
+        if (useHardCodedBool) {
+            target.cachedEffectValues.boolMap[cacheKey] = hardCodedBool;
+        }
+        if (useHardCodedInt) {
+            target.cachedEffectValues.intMap[cacheKey] = hardCodedInt;
+        }
+        if (useHardCodedString) {
+            target.cachedEffectValues.stringMap[cacheKey] = hardCodedString;
+        }
+    }
+}

--- a/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs.meta
+++ b/Assets/Scripts/Effects/EffectSteps/CombatInstanceCacheStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 203b21be231944de8bca79d24bda8796
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/EffectSteps/DebugEffectStep.cs
+++ b/Assets/Scripts/Effects/EffectSteps/DebugEffectStep.cs
@@ -4,25 +4,49 @@ using UnityEngine;
 
 public class DebugEffectStep : EffectStep, IEffectStepCalculation {
     [SerializeField]
+    private string inputCombatInstanceCacheKey;
+
+    [SerializeField]
     private bool genericMap;
     [SerializeField]
     private bool ints;
     [SerializeField]
     private bool strings;
+    [SerializeField]
+    private bool bools;
 
     public DebugEffectStep() {
         effectStepName = "DebugEffectStep";
     }
 
     public override IEnumerator invoke(EffectDocument document) {
+        printValues(document);
+
+        if (inputCombatInstanceCacheKey != "") {
+            List<CombatInstance> instances = document.map.GetList<CombatInstance>(inputCombatInstanceCacheKey);
+            if (instances.Count == 0) {
+                EffectError("No input targets present for key " + inputCombatInstanceCacheKey);
+                yield break;
+            }
+
+            foreach (CombatInstance instance in instances) {
+                Debug.Log("Printing out the cache map for combat instance " + instance.name);
+                printValues(instance.cachedEffectValues);
+            }
+        }
+
+        yield return null;
+    }
+
+    private void printValues(EffectDocument document) {
         if (genericMap)
             document.map.Print();
         if (ints)
             document.printIntMap();
         if (strings)
             document.printStringMap();
-
-        yield return null;
+        if (bools)
+            document.printBoolMap();
     }
 
     public IEnumerator invokeForCalculation(EffectDocument document)

--- a/Assets/Scripts/Entity/CombatInstance.cs
+++ b/Assets/Scripts/Entity/CombatInstance.cs
@@ -45,6 +45,11 @@ public class CombatInstance : MonoBehaviour
 
     private StatusEffectsDisplay statusEffectsDisplay;
 
+    // cachedEffectValues is used to persist state across the entire combat.
+    // For example, if an enemy needs to count the number of cards played in
+    // a given turn, they can load and store a value here.
+    public EffectDocument cachedEffectValues;
+
     private WorldPositionVisualElement wpve;
 
     public void ApplyStatusEffects(StatusEffectType statusEffect, int scale) {
@@ -69,6 +74,8 @@ public class CombatInstance : MonoBehaviour
         if (combatStats.getCurrentHealth() == 0) {
             combatStats.setCurrentHealth(1);
         }
+        // Clear out the cached effect values.
+        this.cachedEffectValues = new EffectDocument();
         this.statusEffectsDisplay = GetComponent<StatusEffectsDisplay>();
         statusEffectsDisplay.Setup(this, wpve);
         this.wpve = wpve;


### PR DESCRIPTION
First non trivial enemy ability
This adds the "Cache Load" and "Cache Store" Effect Steps for manipulating the cache of values on the combat instance.
Only allows messing with ints and bools for now.