### PR TITLE
Refactor and simplify Discard / exhaust effects

### DIFF
--- a/Assets/Scripts/Cards/PlayableCard.cs
+++ b/Assets/Scripts/Cards/PlayableCard.cs
@@ -93,23 +93,21 @@ public class PlayableCard : MonoBehaviour,
         IncrementCastCount();
         EnemyEncounterManager.Instance.combatEncounterState.CastCard(card);
         yield return StartCoroutine(PlayerHand.Instance.OnCardCast(this));
-        PlayerHand.Instance.DiscardCard(this);
-        PlayerHand.Instance.UpdatePlayableCards();
         if (card.cardType.exhaustsWhenPlayed) {
-            CardExhaustVFX();
-            ExhaustCard();
+            yield return StartCoroutine(PlayerHand.Instance.ExhaustCard(this));
         } else {
             yield return StartCoroutine(CardCastVFX(this.gameObject));
-            DiscardCardFromHand();
+            yield return StartCoroutine(PlayerHand.Instance.DiscardCard(this));
         }
+
         // If the hand is empty as a result of playing this card, invoke any subscribers.
         if (PlayerHand.Instance.cardsInHand.Count == 0) {
             Debug.Log("Hand is empty, triggering downstream OnHandEmpty subscribers");
-            PlayerHand.Instance.OnHandEmpty();
+            yield return PlayerHand.Instance.OnHandEmpty();
         }
     }
 
-    private void CardExhaustVFX() {
+    public void CardExhaustVFX() {
         GameObject.Instantiate(
             cardExhaustVFXPrefab,
             this.transform.position,
@@ -170,12 +168,6 @@ public class PlayableCard : MonoBehaviour,
 
     private void IncrementCastCount(){
         card.castCount += 1;
-    }
-
-    public void DiscardCardFromHand() {
-        if (this.gameObject.activeSelf) {
-            DiscardToDeck();
-        }
     }
 
     public void ExhaustCard() {

--- a/Assets/Scripts/Decks/DeckInstance.cs
+++ b/Assets/Scripts/Decks/DeckInstance.cs
@@ -188,16 +188,15 @@ public class DeckInstance : MonoBehaviour
 
     public void ExhaustCard(Card card){
         if(drawPile.Contains(card)){
-            Debug.Log("Exhausting card " + card.id + " from draw pile");
+            Debug.Log("Exhausting card " + card.id + " with name " + card.name + " from draw pile");
             drawPile.Remove(card);
         }
         else if(discardPile.Contains(card)){
-            Debug.Log("Exhausting card " + card.id + " from discard pile");
+            Debug.Log("Exhausting card " + card.id + " with name " + card.name + " from discard pile");
             discardPile.Remove(card);
         } else if (inHand.Contains(card)) {
-            Debug.Log("Exhausting card " + card.id + " from hand");
+            Debug.Log("Exhausting card " + card.id + " with name " + card.name + " from hand");
             inHand.Remove(card);
-            PlayerHand.Instance.SafeRemoveCardFromHand(card);
         }
         exhaustPile.Add(card);
         if (card.cardType.onExhaustEffectWorkflow != null) {

--- a/Assets/Scripts/Effects/EffectSteps/CardInDeckEffect.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CardInDeckEffect.cs
@@ -51,7 +51,12 @@ public class CardInDeckEffect : EffectStep, ITooltipProvider
             numberOfCardsTakenActionOn++;
             switch (effect) {
                 case CardInDeckEffectName.Exhaust:
-                    deckInstances[0].ExhaustCard(card);
+                    PlayableCard cardToExhaust = PlayerHand.Instance.GetCardById(card.id);
+                    if (cardToExhaust != null) {
+                        yield return PlayerHand.Instance.ExhaustCard(cardToExhaust);
+                    } else {
+                        deckInstances[0].ExhaustCard(card);
+                    }
                 break;
 
                 case CardInDeckEffectName.PermaTransform:
@@ -66,7 +71,12 @@ public class CardInDeckEffect : EffectStep, ITooltipProvider
                 break;
 
                 case CardInDeckEffectName.Discard:
-                    deckInstances[0].DiscardCard(card);
+                    PlayableCard cardToDiscard = PlayerHand.Instance.GetCardById(card.id);
+                    if (cardToDiscard != null) {
+                        yield return PlayerHand.Instance.DiscardCard(cardToDiscard);
+                    } else {
+                        deckInstances[0].DiscardCard(card);
+                    }
                 break;
 
                 case CardInDeckEffectName.AddToHand:

--- a/Assets/Scripts/Effects/EffectSteps/CardInHandEffect.cs
+++ b/Assets/Scripts/Effects/EffectSteps/CardInHandEffect.cs
@@ -36,11 +36,11 @@ public class CardInHandEffect : EffectStep, ITooltipProvider
         foreach (PlayableCard card in playableCards) {
             switch (effect) {
                 case CardInHandEffectName.Discard:
-                    card.DiscardCardFromHand();
+                    yield return PlayerHand.Instance.DiscardCard(card);
                 break;
 
                 case CardInHandEffectName.Exhaust:
-                    card.ExhaustCard();
+                    yield return PlayerHand.Instance.ExhaustCard(card);
                 break;
 
                 case CardInHandEffectName.Retain:

--- a/Assets/Scripts/Entity/EntityAbilityInstance.cs
+++ b/Assets/Scripts/Entity/EntityAbilityInstance.cs
@@ -164,7 +164,10 @@ public abstract class EntityAbilityInstance
 
     private IEnumerator OnHandEmpty() {
         Debug.Log("OnHandEmpty ability invoked!!!");
-        yield return setupAndInvokeAbility().GetEnumerator();
+        EffectManager.Instance.QueueEffectWorkflow(
+            new EffectWorkflowClosure(createEffectDocument(), ability.effectWorkflow, null)
+        );
+        yield return null;
     }
 
     private IEnumerator OnCardExhaust(DeckInstance deckFrom, Card card) {


### PR DESCRIPTION
The code from before this commit is very confusing - there is no single entrypoint to exhaust or discard a card. Now, the only entrypoint is through the PlayerHand.Instance. Makes sense, ya?
This is also necessary to fix the Argos work because previously we did not wait until the coroutine completed.