### PR TITLE
Tiefseeker Rework

### DIFF
--- a/Assets/Resources/TooltipConfig/TooltipMapSO.asset
+++ b/Assets/Resources/TooltipConfig/TooltipMapSO.asset
@@ -123,8 +123,7 @@ MonoBehaviour:
     relateBehaviorIndex: 0
     tooltipKeyword: 16
   - title: Hidden Strength
-    description: Exhaust. Draw 1 card from this companion. Give all companions on
-      your team 1 strength.
+    description: Exhaust. Give target companion 3 strength and draw 1 card from it.
     relateBehaviorIndex: 0
     tooltipKeyword: 29
   - title: The Good Stuff

--- a/Assets/Resources/TooltipConfig/TooltipMapSO.asset
+++ b/Assets/Resources/TooltipConfig/TooltipMapSO.asset
@@ -16,134 +16,118 @@ MonoBehaviour:
   - title: Strength
     description: Increases every instance of damage this companion deals
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 6
   - title: Block
     description: Prevents up to X damage dealt to this companion until next turn
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 7
   - title: Exhaust
     description: Removes a card for the rest of combat
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 0
   - title: Draw
     description: Choose a companion to draw X cards from
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 3
   - title: Scry
     description: Look at the top X cards of a chosen deck, discard any number of
       them.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 5
   - title: Discard
     description: Moves the card to the companion's discard pile
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 2
   - title: Attacking
     description: This enemy will attack you next turn
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 11
   - title: Debuffing
     description: This enemy will debuff you next turn
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 12
   - title: Charging
     description: This enemy is just charging up this turn
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 13
   - title: Eye Of Argos
     description: Exhaust. Draw 1 card from this companion, and draw 1 card from a
       random companion
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 14
   - title: Retain
     description: Cards with retain are not discarded at the end of your turn.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 15
   - title: Consume
     description: Remove one aura stack from target companion for an efect
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 17
   - title: Aura
     description: Status that each companion can have. Often grants these companions
       additional powers
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 4
   - title: Invulnerable
     description: A companion with invulnerability takes no damage. Goes away at the
       end of the turn.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 18
   - title: Debt
     description: Unplayable. Lose $1 at the end of the turn
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 19
   - title: Transform
     description: Turn one card into another card. Effect only lasts until end of
       combat.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 20
   - title: Entropy's Burn
     description: Exhaust. When exhausted, deal 5 damage to a random enemy.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 21
   - title: Firebreath
     description: Unplayable. At the end of turn, deal 6 damage to a random enemy.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 22
   - title: Arterial Blade
     description: Lose 1 HP. Deal 1 damage twice. Draw 1 card from this companion
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 25
   - title: Mabs Might
     description: Exhaust. Target companion loses 1 HP, then heals 7 HP. Draw 1 card
       from them
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 24
   - title: Mabs Boon
     description: Exhaust. Heal target companion 3HP.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 23
   - title: Embued Knife
     description: Exhaust. Deal 3 damage for each aura stack on this companion
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 26
   - title: Generated Card
     description: A card added to your deck in any way other than by purchasing it
       at the shop.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 27
   - title: Permanently Remove
     description: Removes a card for a companions deck permanently. This card will
       not return at the end of combat.
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 28
   - title: Bulwark
     description: Draw 1 from this companion. If in hand at the end of the turn, parent
       companion gains 7 block
     relateBehaviorIndex: 0
-    image: {fileID: 0}
     tooltipKeyword: 16
+  - title: Hidden Strength
+    description: Exhaust. Draw 1 card from this companion. Give all companions on
+      your team 1 strength.
+    relateBehaviorIndex: 0
+    tooltipKeyword: 29
+  - title: The Good Stuff
+    description: 0 mana, exhaust. Gain 2 energy and draw 2 cards from this companion
+    relateBehaviorIndex: 0
+    tooltipKeyword: 30

--- a/Assets/ScriptableObjects/CardPools/BidoofRenaissanceCardPool/BuriedTreasureManCardPool.asset
+++ b/Assets/ScriptableObjects/CardPools/BidoofRenaissanceCardPool/BuriedTreasureManCardPool.asset
@@ -13,10 +13,10 @@ MonoBehaviour:
   m_Name: BuriedTreasureManCardPool
   m_EditorClassIdentifier: 
   commonCards:
+  - {fileID: 11400000, guid: 3d201f892524448df9db7f4d46ef8659, type: 2}
   - {fileID: 11400000, guid: c4bffa899c46a4878a3034b3681670cb, type: 2}
-  - {fileID: 11400000, guid: fa92415ff3efc4e5ba67654ebefc0646, type: 2}
   uncommonCards:
-  - {fileID: 11400000, guid: 190910d520bae461389d0581cacd3665, type: 2}
-  - {fileID: 11400000, guid: 466e1a6cb244d41a08bf0fc7474a3fcf, type: 2}
+  - {fileID: 11400000, guid: 123311d752379454795cce96b714886b, type: 2}
+  - {fileID: 11400000, guid: 422b97fe562064a988bb051c55cd00d1, type: 2}
   rareCards:
-  - {fileID: 11400000, guid: 8639043fe6dcc4b61918fe4d8d1b0247, type: 2}
+  - {fileID: 11400000, guid: 0d653966b879d4089b25d85e97c50531, type: 2}

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BetterBuriedTreasure.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BetterBuriedTreasure.asset
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: BetterBuriedTreasure
+  m_EditorClassIdentifier: 
+  Name: Better Buried Treasure
+  Description: Gain $1. Exhaust. Draw 1 card from this companion
+  defaultValues: []
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: de23c3e9343118d4aabf90e19c84243a, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 1
+  retain: 0
+  effectWorkflows:
+  - rid: 5602892491280613593
+  onExhaustEffectWorkflow:
+    rid: 5602892491280613515
+  inPlayerHandEndOfTurnWorkflow:
+    rid: 5602892533381726224
+  tooltips: 
+  references:
+    version: 2
+    RefIds:
+    - rid: 5602892491280613515
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps: []
+    - rid: 5602892491280613593
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 5602892491280613594
+        - rid: 8790164924473540608
+        - rid: 8790164924473540609
+        - rid: 8790164924473540610
+    - rid: 5602892491280613594
+      type: {class: GoldManipulation, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: 
+        goldToAdd: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 5602892533381726224
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps: []
+    - rid: 8790164924473540608
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: self
+        validTargets: 
+        number: 1
+        specialTargetRule: 4
+        cantCancelTargetting: 0
+    - rid: 8790164924473540609
+      type: {class: DrawCards, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DrawCards
+        inputKey: self
+        outputKey: 
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540610
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: self
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BetterBuriedTreasure.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BetterBuriedTreasure.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e042111401a454c2f90e21165addc8f4
+guid: 45034ac88b3ae42a0863c3cb244f2dc5
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BigDig.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BigDig.asset
@@ -10,13 +10,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
-  m_Name: Dig
+  m_Name: BigDig
   m_EditorClassIdentifier: 
-  Name: Dig
-  Description: Scry 1, then draw 1 from target companion
+  Name: Big Dig
+  Description: Scry 3, then draw 2 from target companion
   defaultValues: []
-  Cost: 0
-  Artwork: {fileID: 21300000, guid: 193d15b569c0e194b95f3fdf8f931b36, type: 3}
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: 9a02158f2c6e8479bb9c21bbe525e9e8, type: 3}
   cardCategory: 2
   vfxPrefab: {fileID: 0}
   playable: 1
@@ -68,7 +68,7 @@ MonoBehaviour:
         effectStepName: GetCardsFromDeck
         inputKey: target
         getLimitedNumber: 1
-        numberOfCardsToGet: 1
+        numberOfCardsToGet: 3
         shuffleIfEmpty: 0
         outputKey: topCard
         getAllCardsFromEntities: 0
@@ -82,7 +82,7 @@ MonoBehaviour:
         outputKey: discarded
         promptText: Choose card(s) to discard.
         minTargets: 0
-        maxTargets: 1
+        maxTargets: 3
         getNumberOfTargetsFromKey: 0
         inputNumberOfTargetsKey: 
         randomizeOrder: 0
@@ -101,6 +101,6 @@ MonoBehaviour:
         effectStepName: DrawCards
         inputKey: target
         outputKey: 
-        scale: 1
+        scale: 2
         getScaleFromKey: 0
         inputScaleKey: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BigDig.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/BigDig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d653966b879d4089b25d85e97c50531
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/HiddenStrength.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/HiddenStrength.asset
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: HiddenStrength
+  m_EditorClassIdentifier: 
+  Name: Hidden Strength
+  Description: Exhaust. Give target companion 3 strength and draw 1 card from it.
+  defaultValues: []
+  Cost: 0
+  Artwork: {fileID: 21300000, guid: 69e0a325ef7679a469eebc7cea836acb, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 1
+  retain: 0
+  effectWorkflows:
+  - rid: 5602892533381726232
+  onExhaustEffectWorkflow:
+    rid: -2
+  inPlayerHandEndOfTurnWorkflow:
+    rid: -2
+  tooltips: 
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 1274772082283774277
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: a6a1a26d43bc7114eba88909bdbfccc7, type: 3}
+        scale: 1.5
+    - rid: 5602892533381726232
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 5602892533381726236
+        - rid: 5602892533381726237
+        - rid: 1274772082283774277
+        - rid: 8790164924473540688
+        - rid: 8790164924473540689
+    - rid: 5602892533381726236
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 00000000
+        number: 0
+        specialTargetRule: 0
+        cantCancelTargetting: 0
+    - rid: 5602892533381726237
+      type: {class: ApplyStatus, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: ApplyStatus
+        inputKey: target
+        statusEffect: 0
+        scale: 3
+        getScaleFromKey: 0
+        inputScaleKey: 
+        multiplyByNumAuraStacks: 0
+    - rid: 8790164924473540688
+      type: {class: DrawCards, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DrawCards
+        inputKey: target
+        outputKey: 
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540689
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/HiddenStrength.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/HiddenStrength.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac2bd3250e27f41a8b92b981ebbf94c7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SecureTheBag.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SecureTheBag.asset
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: SecureTheBag
+  m_EditorClassIdentifier: 
+  Name: Secure the Bag
+  Description: Draw 3 cards from target companion, then choose 1 card in your hand
+    and give it retain.
+  defaultValues: []
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: 292ee1eb3f315c9448b8c577d0e6a420, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 0
+  retain: 0
+  effectWorkflows:
+  - rid: 5602892723852673195
+  onExhaustEffectWorkflow:
+    rid: -2
+  inPlayerHandEndOfTurnWorkflow:
+    rid: -2
+  tooltips: 
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 5280922841426165977
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1.5
+    - rid: 5602892723852673195
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 5602892723852673196
+        - rid: 5602892723852673197
+        - rid: 5280922841426165977
+        - rid: 8790164924473540611
+        - rid: 8790164924473540612
+    - rid: 5602892723852673196
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 00000000
+        number: 1
+        specialTargetRule: 0
+        cantCancelTargetting: 0
+    - rid: 5602892723852673197
+      type: {class: DrawCards, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DrawCards
+        inputKey: target
+        outputKey: 
+        scale: 3
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540611
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: targetCard
+        validTargets: 03000000
+        number: 1
+        specialTargetRule: 5
+        cantCancelTargetting: 0
+    - rid: 8790164924473540612
+      type: {class: CardInHandEffect, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: CardInHandEffect
+        inputKey: targetCard
+        effect: 2

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SecureTheBag.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SecureTheBag.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 123311d752379454795cce96b714886b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SourceOfStrength.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SourceOfStrength.asset
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: SourceOfStrength
+  m_EditorClassIdentifier: 
+  Name: Source of Strength
+  Description: Add a Hidden Strength card  to the bottom of a random companion's
+    deck.
+  defaultValues: []
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: 8b7f45e259d8a914ca69c92891ca4bf1, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 0
+  retain: 0
+  effectWorkflows:
+  - rid: 8790164924473540677
+  onExhaustEffectWorkflow:
+    rid: -2
+  inPlayerHandEndOfTurnWorkflow:
+    rid: -2
+  tooltips: 1d000000
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 8790164924473540677
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 8790164924473540678
+        - rid: 8790164924473540679
+        - rid: 8790164924473540680
+    - rid: 8790164924473540678
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 00000000
+        number: 1
+        specialTargetRule: 6
+        cantCancelTargetting: 0
+    - rid: 8790164924473540679
+      type: {class: AddCardsToDeck, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: AddCardsToDeck
+        inputKey: target
+        cardTypes:
+        - {fileID: 11400000, guid: ac2bd3250e27f41a8b92b981ebbf94c7, type: 2}
+        addToDeckMethod: 2
+        getCardsFromKey: 0
+        inputCardsKey: 
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540680
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SourceOfStrength.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/SourceOfStrength.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d201f892524448df9db7f4d46ef8659
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TheGoodStuff.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TheGoodStuff.asset
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: TheGoodStuff
+  m_EditorClassIdentifier: 
+  Name: The Good Stuff
+  Description: Exhaust. Gain 2 energy and draw 2 cards from this companion
+  defaultValues: []
+  Cost: 0
+  Artwork: {fileID: 21300000, guid: 389b74dd33329004e913b282b594ddf3, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 1
+  retain: 0
+  effectWorkflows:
+  - rid: 8790164924473540681
+  onExhaustEffectWorkflow:
+    rid: -2
+  inPlayerHandEndOfTurnWorkflow:
+    rid: -2
+  tooltips: 
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 8790164924473540681
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 8790164924473540682
+        - rid: 8790164924473540683
+        - rid: 8790164924473540684
+        - rid: 8790164924473540685
+    - rid: 8790164924473540682
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 
+        number: 1
+        specialTargetRule: 4
+        cantCancelTargetting: 0
+    - rid: 8790164924473540683
+      type: {class: DrawCards, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: DrawCards
+        inputKey: target
+        outputKey: 
+        scale: 2
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540684
+      type: {class: ManaChange, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: ManaChange
+        scale: 2
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540685
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TheGoodStuff.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TheGoodStuff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33362523cf645431f96ce133b8215173
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TiefseekerStash.asset
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TiefseekerStash.asset
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ae10e10c3e9eb64dad3d693aa88aeee, type: 3}
+  m_Name: TiefseekerStash
+  m_EditorClassIdentifier: 
+  Name: Tiefseeker's Stash
+  Description: Add "The Good Stuff" card to the bottom of a random companion's deck.
+  defaultValues: []
+  Cost: 1
+  Artwork: {fileID: 21300000, guid: 066d04e59f9ced049ad4349c219e424c, type: 3}
+  cardCategory: 2
+  vfxPrefab: {fileID: 0}
+  playable: 1
+  exhaustsWhenPlayed: 0
+  retain: 0
+  effectWorkflows:
+  - rid: 8790164924473540677
+  onExhaustEffectWorkflow:
+    rid: -2
+  inPlayerHandEndOfTurnWorkflow:
+    rid: -2
+  tooltips: 1d000000
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+    - rid: 8790164924473540677
+      type: {class: EffectWorkflow, ns: , asm: Assembly-CSharp}
+      data:
+        effectSteps:
+        - rid: 8790164924473540678
+        - rid: 8790164924473540679
+        - rid: 8790164924473540680
+    - rid: 8790164924473540678
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: target
+        validTargets: 00000000
+        number: 1
+        specialTargetRule: 6
+        cantCancelTargetting: 0
+    - rid: 8790164924473540679
+      type: {class: AddCardsToDeck, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: AddCardsToDeck
+        inputKey: target
+        cardTypes:
+        - {fileID: 11400000}
+        addToDeckMethod: 2
+        getCardsFromKey: 0
+        inputCardsKey: 
+        scale: 1
+        getScaleFromKey: 0
+        inputScaleKey: 
+    - rid: 8790164924473540680
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: target
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TiefseekerStash.asset.meta
+++ b/Assets/ScriptableObjects/CardTypes/BidoofRenaissanceCards/BuriedTreasureManCards/TiefseekerStash.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 422b97fe562064a988bb051c55cd00d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Companions/CompanionTypes/BidoofRenaissanceCompanions/L2BuriedTreasureMan.asset
+++ b/Assets/ScriptableObjects/Companions/CompanionTypes/BidoofRenaissanceCompanions/L2BuriedTreasureMan.asset
@@ -31,7 +31,7 @@ MonoBehaviour:
   abilitiesV2:
   - rid: 205828032053379474
   level: 1
-  upgradeTo: {fileID: 11400000, guid: db7cf55b75dd64de8823119918278ebd, type: 2}
+  upgradeTo: {fileID: 11400000, guid: e042111401a454c2f90e21165addc8f4, type: 2}
   tooltip:
     empty: 0
     lines:

--- a/Assets/ScriptableObjects/Companions/CompanionTypes/BidoofRenaissanceCompanions/L3BuriedTreasureMan.asset
+++ b/Assets/ScriptableObjects/Companions/CompanionTypes/BidoofRenaissanceCompanions/L3BuriedTreasureMan.asset
@@ -36,30 +36,61 @@ MonoBehaviour:
     empty: 0
     lines:
     - title: L3 Tiefseeker
-      description: At the end of combat, gain 5 Gold
+      description: At the start of combat, put a better buried treasure on the bottom
+        of each companion's deck.
+      relatedBehaviorIndex: 0
+    - title: Better Buried Treasure
+      description: 1 Mana. Exhaust. Gain 1 Gold. Draw 1 card from this companion.
       relatedBehaviorIndex: 0
   keepsakeTitle: 
-  keepsakeDescription: At the end of combat, gain 5 Gold
+  keepsakeDescription: At the start of combat, put a better buried treasure on the
+    bottom of each companion's deck.
   references:
     version: 2
     RefIds:
     - rid: 205828032053379474
       type: {class: EntityAbility, ns: , asm: Assembly-CSharp}
       data:
-        abilityTrigger: 1
+        abilityTrigger: 0
         effectSteps:
-        - rid: 205828032053379478
-        - rid: 205828032053379512
-    - rid: 205828032053379478
-      type: {class: GoldManipulation, ns: , asm: Assembly-CSharp}
+        - rid: 205828032053379475
+        - rid: 205828032053379476
+        - rid: 205828032053379477
+        - rid: 8441470952357494974
+    - rid: 205828032053379475
+      type: {class: GetTargets, ns: , asm: Assembly-CSharp}
       data:
-        effectStepName: 
-        goldToAdd: 5
+        effectStepName: GetTargets
+        useInputToLimitOptions: 0
+        inputKey: 
+        outputKey: all
+        validTargets: 00000000
+        number: 1
+        specialTargetRule: 1
+        cantCancelTargetting: 0
+    - rid: 205828032053379476
+      type: {class: AddCardsToDeck, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: AddCardsToDeck
+        inputKey: all
+        cardTypes:
+        - {fileID: 11400000, guid: 45034ac88b3ae42a0863c3cb244f2dc5, type: 2}
+        addToDeckMethod: 2
+        getCardsFromKey: 0
+        inputCardsKey: 
+        scale: 1
         getScaleFromKey: 0
         inputScaleKey: 
-    - rid: 205828032053379512
+    - rid: 205828032053379477
       type: {class: DialogueStep, ns: , asm: Assembly-CSharp}
       data:
         effectStepName: DialogueStep
-        line: we living large baby
+        line: BETTER BURIED TREASURE FOR EVERYONE
         lineTime: 2
+    - rid: 8441470952357494974
+      type: {class: InstantiatePrefab, ns: , asm: Assembly-CSharp}
+      data:
+        effectStepName: InstantiatePrefab
+        inputKey: all
+        prefabToInstantiate: {fileID: 2729960547564495472, guid: b154b671b3d45ef448e7d9eb6a35363a, type: 3}
+        scale: 1

--- a/Assets/Scripts/UI/Tooltips/ITooltipProvider.cs
+++ b/Assets/Scripts/UI/Tooltips/ITooltipProvider.cs
@@ -19,7 +19,7 @@ public enum TooltipKeyword {
 
     AttackIntent,
     DebuffIntent,
-    ChargingIntent, 
+    ChargingIntent,
     EyeOfArgos,
     Retain,
     Bulwark,
@@ -35,9 +35,11 @@ public enum TooltipKeyword {
     EmbuedKnife,
     GeneratedCard,
     PermanentlyRemove,
+    HiddenStrength,
+    TheGoodStuff,
 }
 public interface ITooltipProvider
 {
     TooltipViewModel GetTooltip();
-    
+
 }


### PR DESCRIPTION
## Theme

Hiding value deep in a deck, then search and discover the cards.

## Ability Changes

L1: unchanged
L2: unchanged
L3: Add "Better" buried treasure to the bottom of each deck. Better buried treasure: 0 mana. Gain $1, exhaust, draw 1 card from this companion. It makes it more practical for late game builds.

## Card Changes

### Common

* Dig: 0 mana, scry 1, draw 1 (changed from scry 2, draw 1 because that felt too strong).
* Source of Strength: 1 mana, add a "Hidden Strength" card to the bottom of a random companion's deck. Hidden strength: 0 mana, exhaust, give companion 3 strength and draw 1 card from it.

### Uncommon

* Secure the Bag: 1 mana, draw 3, then choose 1 card in hand to retain
* Tiefseeker Stash: Add "The Good Stuff" card to the bottom of a random companion's deck. The Good Stuff: 0 mana, exhaust. gain 2 energy, draw 2 cards from this companion's deck. Adrenaline, baby.

### Rare

* Big Dig: 1 mana, scry 3, draw 2.

